### PR TITLE
perf: replace blocking ui write with aync write

### DIFF
--- a/lua/haunt/api.lua
+++ b/lua/haunt/api.lua
@@ -18,6 +18,7 @@
 ---@field load fun(): boolean
 ---@field restore_buffer_bookmarks fun(bufnr: number): boolean
 ---@field save fun(): boolean
+---@field save_async fun(callback?: fun(success: boolean))
 ---@field annotate fun(text?: string): boolean
 ---@field clear fun(): boolean
 ---@field clear_all fun(): boolean
@@ -772,6 +773,26 @@ function M.save()
 	ensure_modules()
 	---@cast store -nil
 	return store.save()
+end
+
+--- Save bookmarks to persistent storage asynchronously.
+---
+--- Used for autosave scenarios where blocking I/O would cause UI lag.
+--- Does not block the main thread.
+---
+---@param callback? fun(success: boolean) Optional callback when save completes
+---
+---@usage >lua
+---   require('haunt.api').save_async(function(success)
+---     if not success then
+---       vim.notify("Failed to save bookmarks", vim.log.levels.WARN)
+---     end
+---   end)
+--- <
+function M.save_async(callback)
+	ensure_modules()
+	---@cast store -nil
+	store.save_async(callback)
 end
 
 --- Jump to the next bookmark in the current buffer.

--- a/lua/haunt/init.lua
+++ b/lua/haunt/init.lua
@@ -211,8 +211,8 @@ local function save_all_bookmarks()
 	end
 
 	local api = require("haunt.api")
-	if api.save then
-		api.save()
+	if api.save_async then
+		api.save_async()
 	end
 end
 

--- a/lua/haunt/store.lua
+++ b/lua/haunt/store.lua
@@ -4,6 +4,7 @@
 ---@field load fun(): boolean
 ---@field reload fun()
 ---@field save fun(): boolean
+---@field save_async fun(callback?: fun(success: boolean))
 ---@field get_quickfix_items fun(opts?: QuickfixOpts): QuickfixItem[]
 ---@field find_by_id fun(bookmark_id: string): Bookmark|nil, number|nil
 ---@field get_bookmark_at_line fun(filepath: string, line: number): Bookmark|nil, number|nil
@@ -312,6 +313,18 @@ function M.save()
 	---@cast persistence -nil
 	local success = persistence.save_bookmarks(bookmarks)
 	return success
+end
+
+--- Save bookmarks to persistent storage asynchronously.
+---
+--- Used for autosave scenarios where blocking I/O would cause UI lag.
+--- Does not block the main thread.
+---
+---@param callback? fun(success: boolean) Optional callback when save completes
+function M.save_async(callback)
+	ensure_persistence()
+	---@cast persistence -nil
+	persistence.save_bookmarks_async(bookmarks, nil, callback)
 end
 
 --- Add a bookmark to the store


### PR DESCRIPTION
## Checklist
- [x] Read `CONTRIBUTING.md`
- [x] Ran tests (`./scripts/test`) locally
- [x] Formatted with Stylua
- [x] Added tests if necessary
- [x] Updated documentation(inline to source code) if applicable
- [x] Updated `README.md` if applicable

## Summary
<!-- What does this PR change and/or fix? -->
save files async for a non blocking UI