### PR TITLE
Bugfix 74/lazily create dir and file

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,19 @@
 # Changelog
 
+## [0.8.0](https://github.com/TheNoeTrevino/haunt.nvim/compare/v0.7.1...v0.8.0) (2026-02-05)
+
+
+### Features
+
+* annotation suffix ([1cf404c](https://github.com/TheNoeTrevino/haunt.nvim/commit/1cf404c8c82bd91b6f7b1f180daea3ae0a247976))
+
+
+### Bug Fixes
+
+* delayed window closing ([adba00a](https://github.com/TheNoeTrevino/haunt.nvim/commit/adba00a563f439f21ab3acc17de8262aab6030f6))
+* highlights getting wiped when colorscheme changes ([92986ea](https://github.com/TheNoeTrevino/haunt.nvim/commit/92986ea27b9562bc19cc3c00f3af5c330bb0af13))
+* highlights getting wiped when colorscheme changes ([2f067c7](https://github.com/TheNoeTrevino/haunt.nvim/commit/2f067c76d16b06fc32df27e18c6072b25bc137cb))
+
 ## [0.7.1](https://github.com/TheNoeTrevino/haunt.nvim/compare/v0.7.0...v0.7.1) (2026-01-28)
 
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,13 @@
 # Changelog
 
+## [0.8.1](https://github.com/TheNoeTrevino/haunt.nvim/compare/v0.8.0...v0.8.1) (2026-02-23)
+
+
+### Bug Fixes
+
+* use cache instead of fetching ([740d664](https://github.com/TheNoeTrevino/haunt.nvim/commit/740d664987fd13eadf31d05511ce4090ec149c7e))
+* use cache instead of fetching ([8d82b88](https://github.com/TheNoeTrevino/haunt.nvim/commit/8d82b88d50049803966089ee85574c1a22fd89be))
+
 ## [0.8.0](https://github.com/TheNoeTrevino/haunt.nvim/compare/v0.7.1...v0.8.0) (2026-02-05)
 
 

--- a/lua/haunt/persistence.lua
+++ b/lua/haunt/persistence.lua
@@ -115,11 +115,16 @@ function M.set_data_dir(dir)
 	custom_data_dir = expanded
 end
 
+---@return string data_dir The haunt data directory path
+local function get_data_dir()
+	local config = require("haunt.config")
+	return custom_data_dir or config.DEFAULT_DATA_DIR
+end
+
 --- Ensures the haunt data directory exists
 ---@return string data_dir The haunt data directory path
 function M.ensure_data_dir()
-	local config = require("haunt.config")
-	local data_dir = custom_data_dir or config.DEFAULT_DATA_DIR
+	local data_dir = get_data_dir()
 	vim.fn.mkdir(data_dir, "p")
 	return data_dir
 end
@@ -159,7 +164,7 @@ end
 ---@return string path The full path to the storage file
 function M.get_storage_path()
 	local config = require("haunt.config").get()
-	local data_dir = M.ensure_data_dir()
+	local data_dir = get_data_dir()
 	local git_info = M.get_git_info()
 	local repo_root = git_info.root or vim.fn.getcwd()
 
@@ -192,6 +197,11 @@ function M.save_bookmarks(bookmarks, filepath)
 	if not storage_path then
 		vim.notify("haunt.nvim: save_bookmarks: could not determine storage path", vim.log.levels.ERROR)
 		return false
+	end
+
+	if #bookmarks == 0 then
+		vim.fn.delete(storage_path)
+		return true
 	end
 
 	-- Ensure storage directory exists
@@ -237,6 +247,14 @@ function M.save_bookmarks_async(bookmarks, filepath, callback)
 	if not storage_path then
 		if callback then
 			callback(false)
+		end
+		return
+	end
+
+	if #bookmarks == 0 then
+		vim.fn.delete(storage_path)
+		if callback then
+			callback(true)
 		end
 		return
 	end

--- a/tests/persistence_spec.lua
+++ b/tests/persistence_spec.lua
@@ -92,6 +92,46 @@ describe("haunt.persistence", function()
 		end)
 	end)
 
+	describe("lazy directory creation", function()
+		local temp_dir
+
+		before_each(function()
+			temp_dir = vim.fn.tempname() .. "_haunt_lazy/"
+			persistence.set_data_dir(temp_dir)
+		end)
+
+		after_each(function()
+			persistence.set_data_dir(nil)
+			helpers.cleanup_temp_dir(temp_dir)
+		end)
+
+		it("get_storage_path does not create the data dir", function()
+			assert.are.equal(0, vim.fn.isdirectory(temp_dir))
+			persistence.get_storage_path()
+			assert.are.equal(0, vim.fn.isdirectory(temp_dir))
+		end)
+
+		it("load_bookmarks does not create the data dir", function()
+			assert.are.equal(0, vim.fn.isdirectory(temp_dir))
+			local loaded = persistence.load_bookmarks()
+			assert.are.equal(0, #loaded)
+			assert.are.equal(0, vim.fn.isdirectory(temp_dir))
+		end)
+
+		it("save_bookmarks with empty list does not create the data dir", function()
+			assert.are.equal(0, vim.fn.isdirectory(temp_dir))
+			assert.is_true(persistence.save_bookmarks({}))
+			assert.are.equal(0, vim.fn.isdirectory(temp_dir))
+		end)
+
+		it("save_bookmarks with non-empty list creates the data dir", function()
+			assert.are.equal(0, vim.fn.isdirectory(temp_dir))
+			local bookmarks = { persistence.create_bookmark("/tmp/lazy.lua", 1, "Note") }
+			assert.is_true(persistence.save_bookmarks(bookmarks))
+			assert.are.equal(1, vim.fn.isdirectory(temp_dir))
+		end)
+	end)
+
 	describe("set_data_dir", function()
 		after_each(function()
 			persistence.set_data_dir(nil)
@@ -232,12 +272,24 @@ describe("haunt.persistence", function()
 			assert.are.equal(0, #loaded)
 		end)
 
-		it("handles empty bookmark list", function()
+		it("does not create a file for an empty bookmark list", function()
 			local save_ok = persistence.save_bookmarks({}, test_file)
 			assert.is_true(save_ok)
+			assert.are.equal(0, vim.fn.filereadable(test_file))
 
 			local loaded = persistence.load_bookmarks(test_file)
 			assert.are.equal(0, #loaded)
+		end)
+
+		it("deletes an existing file when saving an empty list", function()
+			local bookmarks = {
+				persistence.create_bookmark("/tmp/file1.lua", 10, "First"),
+			}
+			assert.is_true(persistence.save_bookmarks(bookmarks, test_file))
+			assert.are.equal(1, vim.fn.filereadable(test_file))
+
+			assert.is_true(persistence.save_bookmarks({}, test_file))
+			assert.are.equal(0, vim.fn.filereadable(test_file))
 		end)
 
 		it("handles large bookmark sets (100 bookmarks)", function()


### PR DESCRIPTION
## Checklist
- [x] Read `CONTRIBUTING.md`
- [x] Ran tests (`./scripts/test`) locally
- [x] Formatted with Stylua
- [x] Added tests if necessary
- [x] Updated documentation(inline to source code) if applicable
- [x] Updated `README.md` if applicable

## Summary
<!-- What does this PR change and/or fix? -->
Lazily create datadir. Do not call `ensure_datadir` on open. Create a bunch of directories if users have a dynamic setting of the `data_dir` field

Fixes: #74 