### PR TITLE
feat: shell commands dont block startup

### DIFF
--- a/lua/haunt/init.lua
+++ b/lua/haunt/init.lua
@@ -274,7 +274,7 @@ function M._setup_restoration_autocmd()
 		end
 	end
 
-	require("haunt.migration").auto_migrate()
+	require("haunt.migration").ensure_done()
 end
 
 -- Check if any bookmarks exist
@@ -330,8 +330,13 @@ function M.setup(opts)
 		require("haunt.persistence").set_data_dir(user_config.data_dir)
 	end
 
-	-- Run inline so the user's data_dir is applied before migration probes for files.
-	require("haunt.migration").auto_migrate()
+	-- Defer migration off the startup path. Readers gate on migration.ensure_done()
+	-- (see persistence.load_bookmarks), so this is purely a latency optimization —
+	-- if a reader fires before this scheduled callback runs, the reader runs the
+	-- migration synchronously itself.
+	vim.schedule(function()
+		require("haunt.migration").auto_migrate()
+	end)
 end
 
 --- Get the current configuration.

--- a/lua/haunt/migration.lua
+++ b/lua/haunt/migration.lua
@@ -18,6 +18,7 @@
 ---@class MigrationModule
 ---@field migrate_current_project fun()
 ---@field auto_migrate fun()
+---@field ensure_done fun()
 ---@field _reset_for_testing fun()
 
 ---@private
@@ -225,9 +226,22 @@ function M.migrate_current_project()
 	do_migrate(info, old_path, new_path, data)
 end
 
+---@type boolean
+local _done = false
+
 --- Auto-migrate on startup. Silent on every non-issue; emits an idempotent
 --- ERROR notify only when both v1 and v2 storage files exist for the project.
+---
+--- Gated by a session-scoped `_done` flag so it runs at most once per session.
+--- setup() schedules this for startup latency; the first reader that hits
+--- persistence.load_bookmarks calls ensure_done() to close the race.
 function M.auto_migrate()
+	if _done then
+		return
+	end
+	-- Set the flag before doing any work so reentrant calls (e.g. via the
+	-- api.reload() at the end of do_migrate, which loads bookmarks) short-circuit.
+	_done = true
 	local paths = resolve_paths()
 	if not paths then
 		return
@@ -259,10 +273,21 @@ function M.auto_migrate()
 	do_migrate(info, old_path, new_path, data)
 end
 
+--- Synchronously block until the one-shot auto_migrate has run for this session.
+--- Readers (persistence.load_bookmarks) call this so a scheduled auto_migrate
+--- never races a synchronous read.
+function M.ensure_done()
+	if _done then
+		return
+	end
+	M.auto_migrate()
+end
+
 --- Reset session-scoped state for tests.
 ---@private
 function M._reset_for_testing()
 	_dual_state_notified = {}
+	_done = false
 end
 
 return M

--- a/lua/haunt/persistence.lua
+++ b/lua/haunt/persistence.lua
@@ -266,6 +266,10 @@ end
 ---@param filepath? string Optional custom file path (defaults to git-based path)
 ---@return table bookmarks Array of bookmarks, or empty table if file doesn't exist or on error
 function M.load_bookmarks(filepath)
+	-- Close the race with a scheduled auto_migrate from setup(): any reader
+	-- blocks here until migration has run for this session.
+	require("haunt.migration").ensure_done()
+
 	-- Get storage path
 	local storage_path = filepath or M.get_storage_path()
 	if not storage_path then

--- a/tests/migration_spec.lua
+++ b/tests/migration_spec.lua
@@ -637,7 +637,7 @@ describe("haunt.migration", function()
 				end
 			end)
 
-			it("runs synchronously from haunt.setup() at the configured data_dir", function()
+			it("runs at the configured data_dir, gated by ensure_done()", function()
 				assert.are_not.equal(v1_path, v2_path)
 
 				require("haunt").setup({
@@ -645,8 +645,11 @@ describe("haunt.migration", function()
 					per_branch_bookmarks = true,
 				})
 
-				-- setup() must finish migration before returning — no
-				-- vim.schedule, no UIEnter, no waiting.
+				-- setup() schedules auto_migrate for startup latency.
+				-- Any reader (load_bookmarks) calls ensure_done() to close
+				-- the race; do that explicitly here.
+				migration.ensure_done()
+
 				assert.are.equal(0, vim.fn.filereadable(v1_path))
 				assert.are.equal(1, vim.fn.filereadable(v1_path .. ".v1.bak"))
 				assert.are.equal(1, vim.fn.filereadable(v2_path))
@@ -667,6 +670,7 @@ describe("haunt.migration", function()
 					data_dir = custom_data_dir,
 					per_branch_bookmarks = true,
 				})
+				migration.ensure_done()
 
 				assert.are.equal(1, vim.fn.filereadable(v1_path .. ".v1.bak"))
 				assert.are.equal(1, vim.fn.filereadable(v2_path))


### PR DESCRIPTION
## Checklist
- [x] Read `CONTRIBUTING.md`
- [x] Ran tests (`./scripts/test`) locally
- [x] Formatted with Stylua
- [x] Added tests if necessary
- [x] Updated documentation(inline to source code) if applicable
- [x] Updated `README.md` if applicable

## Summary
<!-- What does this PR change and/or fix? -->
Speedup startup time with a `vim.schedule` for the auto migration