### PR TITLE
feat: add above-annotations

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,24 @@
 # Changelog
 
+## [1.2.0](https://github.com/TheNoeTrevino/haunt.nvim/compare/v1.1.0...v1.2.0) (2026-05-11)
+
+
+### Features
+
+* add hook registry and event definitions ([00052f9](https://github.com/TheNoeTrevino/haunt.nvim/commit/00052f96c6d2740433fcc8a943e87ca800034156))
+* emit hook events from bookmark lifecycle ([727df1b](https://github.com/TheNoeTrevino/haunt.nvim/commit/727df1bbeb0ef99b549505684ec9a3b9cbd82d4e))
+* **plugin:** register :HauntReload command ([1e33bb8](https://github.com/TheNoeTrevino/haunt.nvim/commit/1e33bb8d342b29ce5843850607e37f00388aaeed))
+* **store:** expose loaded storage path ([3b48573](https://github.com/TheNoeTrevino/haunt.nvim/commit/3b48573bdea8f3a4fd9dc9379c3d3233bd093434))
+* **watcher:** auto-reload bookmarks on branch checkout ([640694f](https://github.com/TheNoeTrevino/haunt.nvim/commit/640694f31f852dc2a42d8d97a4b5263932ac00da))
+
+
+### Bug Fixes
+
+* **api:** roll back state when save fails during delete ([25a45b4](https://github.com/TheNoeTrevino/haunt.nvim/commit/25a45b44dce13abd660b4b9d4c11a508e0a3b62b))
+* **hooks:** unregister once-wrapper before invoking user callback ([4eac63b](https://github.com/TheNoeTrevino/haunt.nvim/commit/4eac63be35fc41ac6668bfbc8f3b1668300ef7c7))
+* **store:** load_bookmarks error handling ([31a971e](https://github.com/TheNoeTrevino/haunt.nvim/commit/31a971e55e4c6858c1f9f4a4bedcb1b5596b8376))
+* **watcher:** clear watched gitdir when handle is closed ([7006993](https://github.com/TheNoeTrevino/haunt.nvim/commit/7006993616811b104058e13779e1f415b979f316))
+
 ## [1.1.0](https://github.com/TheNoeTrevino/haunt.nvim/compare/v1.0.0...v1.1.0) (2026-05-04)
 
 

--- a/README.md
+++ b/README.md
@@ -91,6 +91,7 @@ return {
     annotation_suffix = "",
     line_hl = nil,
     virt_text_pos = "eol",
+    above_max_width = 80,
     data_dir = nil,
     per_branch_bookmarks = true,
     picker = "auto", -- "auto", "snacks", "telescope", or "fzf"

--- a/README.md
+++ b/README.md
@@ -92,6 +92,7 @@ return {
     line_hl = nil,
     virt_text_pos = "eol",
     above_max_width = 80,
+    above_border = "rounded", -- "single", "double", "none", or character array
     data_dir = nil,
     per_branch_bookmarks = true,
     picker = "auto", -- "auto", "snacks", "telescope", or "fzf"
@@ -163,6 +164,20 @@ return {
   end,
 }
 ```
+
+### Above Annotations
+
+<details>
+  <summary>Click to expand</summary>
+
+Set `virt_text_pos = "above"` to display annotations in a bordered box above the line instead of inline. The box wraps long text and adapts to the window width.
+
+- `above_max_width` — maximum box width in columns (default `80`, clamped to window width)
+- `above_border` — border style: `"rounded"` (default), `"single"`, `"double"`, `"none"`, or a character array like `{"╭", "─", "╮", "│", "╯", "─", "╰", "│"}`
+
+![Above annotation demo](https://github.com/user-attachments/assets/4e70c3a6-5317-461e-abd1-c721e676d781)
+
+</details>
 
 ## Usage
 

--- a/doc/haunt.txt
+++ b/doc/haunt.txt
@@ -300,6 +300,7 @@ Default configuration: ~
   	line_hl = nil,
   	virt_text_pos = "eol",
 	above_max_width = 80,
+	above_border = "rounded",
   	data_dir = nil,
   	per_branch_bookmarks = true,
   	picker = "auto",
@@ -318,6 +319,7 @@ Fields ~
 {line_hl} `(optional)` `(string|nil)` The highlight group for the entire line (default: nil)
 {virt_text_pos} `(optional)` `(string)` Position of virtual text: "eol" (default), "eol_right_align", "overlay", "right_align", "inline", "above"
 {above_max_width} `(optional)` `(number)` Maximum width for the "above" box (default: 80). The box is also clamped to the window width. Only applies when virt_text_pos = "above"
+{above_border} `(optional)` `(string|string[]|(string|string[])[])` Border style for the "above" box. Preset strings: "rounded" (default), "single", "double", "none". Also accepts an array of characters (clockwise from top-left); any length that divides 8 is cycled. Each element can be a string or {char, hl_group}.
 {data_dir} `(optional)` `(string|nil)` Custom data directory path (default: vim.fn.stdpath("data") .. "/haunt/")
 {picker} `(optional)` "`(snacks)`"|"telescope"|"fzf"|"auto" Which picker to use: "snacks", "telescope", "fzf", or "auto" (default: "auto"). "auto" tries Snacks first, then Telescope, then fzf-lua, then vim.ui.select
 {picker_keys} `(table<string, table>)` Keybindings for picker actions (default: {delete = {key = 'd', mode = {'n'}}, edit_annotation = {key = 'a', mode = {'n'}}})

--- a/doc/haunt.txt
+++ b/doc/haunt.txt
@@ -299,6 +299,7 @@ Default configuration: ~
   	annotation_suffix = "",
   	line_hl = nil,
   	virt_text_pos = "eol",
+	above_max_width = 80,
   	data_dir = nil,
   	per_branch_bookmarks = true,
   	picker = "auto",
@@ -315,7 +316,8 @@ Fields ~
 {annotation_prefix} `(optional)` `(string)` Text to display before the annotation (default: '  ')
 {annotation_suffix} `(optional)` `(string)` Text to display after the annotation (default: '')
 {line_hl} `(optional)` `(string|nil)` The highlight group for the entire line (default: nil)
-{virt_text_pos} `(optional)` `(string)` Position of virtual text: "eol" (default), "eol_right_align", "overlay", "right_align", "inline"
+{virt_text_pos} `(optional)` `(string)` Position of virtual text: "eol" (default), "eol_right_align", "overlay", "right_align", "inline", "above"
+{above_max_width} `(optional)` `(number)` Maximum width for the "above" box (default: 80). The box is also clamped to the window width. Only applies when virt_text_pos = "above"
 {data_dir} `(optional)` `(string|nil)` Custom data directory path (default: vim.fn.stdpath("data") .. "/haunt/")
 {picker} `(optional)` "`(snacks)`"|"telescope"|"fzf"|"auto" Which picker to use: "snacks", "telescope", "fzf", or "auto" (default: "auto"). "auto" tries Snacks first, then Telescope, then fzf-lua, then vim.ui.select
 {picker_keys} `(table<string, table>)` Keybindings for picker actions (default: {delete = {key = 'd', mode = {'n'}}, edit_annotation = {key = 'a', mode = {'n'}}})

--- a/lua/haunt/api.lua
+++ b/lua/haunt/api.lua
@@ -29,6 +29,7 @@
 ---@field cleanup_buffer_tracking fun(bufnr: number)
 ---@field change_data_dir fun(new_dir: string|nil): boolean
 ---@field reload fun(reason?: ReloadReason): boolean
+---@field refresh_above_annotations fun()
 ---@field _reset_for_testing fun()
 
 ---@private
@@ -1045,6 +1046,58 @@ end
 --- WARNING: This will clear ALL bookmarks from memory without persisting
 --- Only use in test environments
 ---@private
+--- Re-render all visible "above" annotations so they adapt to the current
+--- window width. Called on resize events.
+function M.refresh_above_annotations()
+	ensure_modules()
+	---@cast store -nil
+	---@cast display -nil
+
+	if not _annotations_visible then
+		return
+	end
+
+	local cfg = require("haunt.config").get()
+	if (cfg.virt_text_pos or "eol") ~= "above" then
+		return
+	end
+
+	local bookmarks = store.get_all_raw()
+	for _, bookmark in ipairs(bookmarks) do
+		if not bookmark.note or not bookmark.annotation_extmark_id then
+			goto continue
+		end
+
+		local bufnr = vim.fn.bufnr(bookmark.file)
+		if bufnr == -1 or not vim.api.nvim_buf_is_valid(bufnr) then
+			goto continue
+		end
+
+		local current_line = nil
+		if bookmark.extmark_id then
+			current_line = display.get_extmark_line(bufnr, bookmark.extmark_id)
+		end
+		if not current_line then
+			current_line = bookmark.line
+		end
+
+		local line_count = vim.api.nvim_buf_line_count(bufnr)
+		if current_line < 1 or current_line > line_count then
+			goto continue
+		end
+
+		display.hide_annotation(bufnr, bookmark.annotation_extmark_id)
+		local ok, extmark_id = pcall(display.show_annotation, bufnr, current_line, bookmark.note)
+		if ok then
+			bookmark.annotation_extmark_id = extmark_id
+		else
+			bookmark.annotation_extmark_id = nil
+		end
+
+		::continue::
+	end
+end
+
 function M._reset_for_testing()
 	ensure_modules()
 	---@cast store -nil

--- a/lua/haunt/config.lua
+++ b/lua/haunt/config.lua
@@ -29,7 +29,8 @@ M.DEFAULT_DATA_DIR = vim.fn.stdpath("data") .. "/haunt/"
 ---@field annotation_prefix? string Text to display before the annotation (default: '  ')
 ---@field annotation_suffix? string Text to display after the annotation (default: '')
 ---@field line_hl? string|nil The highlight group for the entire line (default: nil)
----@field virt_text_pos? string Position of virtual text: "eol" (default), "eol_right_align", "overlay", "right_align", "inline"
+---@field virt_text_pos? string Position of virtual text: "eol" (default), "eol_right_align", "overlay", "right_align", "inline", "above"
+---@field above_max_width? number Maximum width for the "above" box (default: 80). The box is also clamped to the window width. Only applies when virt_text_pos = "above"
 ---@field data_dir? string|nil Custom data directory path (default: vim.fn.stdpath("data") .. "/haunt/")
 ---@field picker? "snacks"|"telescope"|"fzf"|"auto" Which picker to use: "snacks", "telescope", "fzf", or "auto" (default: "auto"). "auto" tries Snacks first, then Telescope, then fzf-lua, then vim.ui.select
 ---@field picker_keys table<string, table> Keybindings for picker actions (default: {delete = {key = 'd', mode = {'n'}}, edit_annotation = {key = 'a', mode = {'n'}}})
@@ -44,6 +45,7 @@ M.DEFAULT = {
 	annotation_suffix = "",
 	line_hl = nil,
 	virt_text_pos = "eol",
+	above_max_width = 80,
 	data_dir = nil,
 	per_branch_bookmarks = true,
 	picker = "auto",

--- a/lua/haunt/config.lua
+++ b/lua/haunt/config.lua
@@ -31,6 +31,7 @@ M.DEFAULT_DATA_DIR = vim.fn.stdpath("data") .. "/haunt/"
 ---@field line_hl? string|nil The highlight group for the entire line (default: nil)
 ---@field virt_text_pos? string Position of virtual text: "eol" (default), "eol_right_align", "overlay", "right_align", "inline", "above"
 ---@field above_max_width? number Maximum width for the "above" box (default: 80). The box is also clamped to the window width. Only applies when virt_text_pos = "above"
+---@field above_border? string|string[]|(string|string[])[] Border style for the "above" box. Preset strings: "rounded" (default), "single", "double", "none". Also accepts an array of characters (clockwise from top-left); any length that divides 8 is cycled. Each element can be a string or {char, hl_group}.
 ---@field data_dir? string|nil Custom data directory path (default: vim.fn.stdpath("data") .. "/haunt/")
 ---@field picker? "snacks"|"telescope"|"fzf"|"auto" Which picker to use: "snacks", "telescope", "fzf", or "auto" (default: "auto"). "auto" tries Snacks first, then Telescope, then fzf-lua, then vim.ui.select
 ---@field picker_keys table<string, table> Keybindings for picker actions (default: {delete = {key = 'd', mode = {'n'}}, edit_annotation = {key = 'a', mode = {'n'}}})
@@ -46,6 +47,7 @@ M.DEFAULT = {
 	line_hl = nil,
 	virt_text_pos = "eol",
 	above_max_width = 80,
+	above_border = "rounded",
 	data_dir = nil,
 	per_branch_bookmarks = true,
 	picker = "auto",

--- a/lua/haunt/display.lua
+++ b/lua/haunt/display.lua
@@ -170,21 +170,82 @@ local function wrap_text(text, max_width)
 	return result
 end
 
+local BORDER_PRESETS = {
+	rounded = { "╭", "─", "╮", "│", "╯", "─", "╰", "│" },
+	single = { "┌", "─", "┐", "│", "┘", "─", "└", "│" },
+	double = { "╔", "═", "╗", "║", "╝", "═", "╚", "║" },
+}
+
+--- Resolve a border spec (preset string or array) into an 8-element array of {char, hl} pairs.
+--- Accepts preset strings ("rounded", "single", "double", "none") or an array of characters
+--- whose length divides 8 (cycled to fill all 8 positions). Each element can be a string or
+--- {char, hl_group}.
+---@param spec string|string[]|(string|string[])[]|nil
+---@param default_hl string Fallback highlight group when the element doesn't specify one
+---@return {[1]: string, [2]: string}[] border 8 elements: {char, hl_group}
+local function resolve_border(spec, default_hl)
+	if spec == nil or spec == "rounded" then
+		spec = BORDER_PRESETS.rounded
+	elseif type(spec) == "string" then
+		if spec == "none" then
+			return vim.fn["repeat"]({ { "", default_hl } }, 8)
+		end
+		local preset = BORDER_PRESETS[spec]
+		if not preset then
+			vim.notify(
+				string.format("haunt.nvim: unknown above_border preset %q, falling back to 'rounded'", spec),
+				vim.log.levels.WARN
+			)
+			preset = BORDER_PRESETS.rounded
+		end
+		spec = preset
+	end
+
+	if type(spec) ~= "table" or #spec == 0 then
+		vim.notify("haunt.nvim: invalid above_border value, falling back to 'rounded'", vim.log.levels.WARN)
+		spec = BORDER_PRESETS.rounded
+	elseif 8 % #spec ~= 0 then
+		vim.notify(
+			string.format(
+				"haunt.nvim: above_border array length %d does not divide 8, falling back to 'rounded'",
+				#spec
+			),
+			vim.log.levels.WARN
+		)
+		spec = BORDER_PRESETS.rounded
+	end
+
+	local raw = spec
+	local n = #raw
+	local out = {}
+	for i = 1, 8 do
+		local elem = raw[((i - 1) % n) + 1]
+		if type(elem) == "table" then
+			out[i] = { elem[1] or "", elem[2] or default_hl }
+		else
+			out[i] = { elem or "", default_hl }
+		end
+	end
+	return out
+end
+
 --- Build virtual lines for a boxed annotation displayed above the target line
 ---@param note string The annotation text (may contain newlines)
 ---@param prefix string Text to display before the first line (e.g. icon)
 ---@param hl_group string Highlight group for the content
----@param border_hl string Highlight group for the box border
+---@param border table Resolved 8-element border array from resolve_border()
 ---@param wrap_at number Max content width before wrapping
 ---@return table virt_lines Array of virtual line chunks for nvim_buf_set_extmark
-local function build_box_lines(note, prefix, hl_group, border_hl, wrap_at)
+local function build_box_lines(note, prefix, hl_group, border, wrap_at)
 	-- Split on literal "\n" (backslash-n typed into vim.fn.input) and real newlines
 	local lines = vim.split(note:gsub("\\n", "\n"), "\n")
 	local prefix_width = vim.fn.strdisplaywidth(prefix)
 	local indent = string.rep(" ", prefix_width)
 
-	-- 2 border chars (│…│) + 1 trailing padding take display space from wrap_at
-	local max_content_width = math.max((tonumber(wrap_at) or 80) - 3, 1)
+	local left_w = vim.fn.strdisplaywidth(border[8][1])
+	local right_w = vim.fn.strdisplaywidth(border[4][1])
+	local border_overhead = left_w + right_w + 1
+	local max_content_width = math.max((tonumber(wrap_at) or 80) - border_overhead, 1)
 
 	local content = {}
 	local max_width = 0
@@ -221,24 +282,32 @@ local function build_box_lines(note, prefix, hl_group, border_hl, wrap_at)
 	local inner_width = max_content_width + 1
 	local virt_lines = {}
 
+	local topleft, top, topright = border[1], border[2], border[3]
+	local right, bottomright = border[4], border[5]
+	local bottom, bottomleft, left = border[6], border[7], border[8]
+
 	-- Top border
 	table.insert(virt_lines, {
-		{ "╭" .. string.rep("─", inner_width) .. "╮", border_hl },
+		{ topleft[1], topleft[2] },
+		{ string.rep(top[1], inner_width), top[2] },
+		{ topright[1], topright[2] },
 	})
 
 	-- Body rows
 	for _, text in ipairs(content) do
 		local fill = inner_width - vim.fn.strdisplaywidth(text)
 		table.insert(virt_lines, {
-			{ "│", border_hl },
+			{ left[1], left[2] },
 			{ text .. string.rep(" ", fill), hl_group },
-			{ "│", border_hl },
+			{ right[1], right[2] },
 		})
 	end
 
 	-- Bottom border
 	table.insert(virt_lines, {
-		{ "╰" .. string.rep("─", inner_width) .. "╯", border_hl },
+		{ bottomleft[1], bottomleft[2] },
+		{ string.rep(bottom[1], inner_width), bottom[2] },
+		{ bottomright[1], bottomright[2] },
 	})
 
 	return virt_lines
@@ -280,7 +349,8 @@ function M.show_annotation(bufnr, line, note)
 			local info = vim.fn.getwininfo(win)[1]
 			text_width = math.min(max_width, info.width - info.textoff)
 		end
-		local box_lines = build_box_lines(note .. suffix, prefix, hl_group, "HauntAnnotationBorder", text_width)
+		local border = resolve_border(cfg.above_border, "HauntAnnotationBorder")
+		local box_lines = build_box_lines(note .. suffix, prefix, hl_group, border, text_width)
 		-- virt_lines_above on row 0 is invisible (Neovim clips virtual lines
 		-- above the window topline). Fall back to placing below line 1.
 		local extmark_id = vim.api.nvim_buf_set_extmark(bufnr, M.get_namespace(), line - 1, 0, {

--- a/lua/haunt/display.lua
+++ b/lua/haunt/display.lua
@@ -40,6 +40,11 @@ local function define_highlights()
 	if vim.tbl_isempty(existing) then
 		vim.api.nvim_set_hl(0, "HauntAnnotation", { link = "DiagnosticVirtualTextHint" })
 	end
+
+	local existing_border = vim.api.nvim_get_hl(0, { name = "HauntAnnotationBorder" })
+	if vim.tbl_isempty(existing_border) then
+		vim.api.nvim_set_hl(0, "HauntAnnotationBorder", { link = "FloatBorder" })
+	end
 end
 
 local function ensure_highlights_defined()
@@ -114,6 +119,131 @@ function M.is_initialized()
 	return config.is_setup()
 end
 
+--- Word-wrap a string to fit within max_width display columns.
+--- Breaks at word boundaries when possible, hard-breaks otherwise.
+---@param text string The text to wrap
+---@param max_width number Maximum display width per line
+---@return string[] wrapped The wrapped lines
+local function wrap_text(text, max_width)
+	max_width = tonumber(max_width) or 1
+	if max_width < 1 then
+		max_width = 1
+	end
+
+	if vim.fn.strdisplaywidth(text) <= max_width then
+		return { text }
+	end
+
+	local result = {}
+	local remaining = text
+
+	while vim.fn.strdisplaywidth(remaining) > max_width do
+		local cut
+		local hard_cut = 0
+		local char_count = vim.fn.strchars(remaining)
+
+		-- Find the last space that fits within max_width.
+		for i = 1, char_count do
+			local segment = vim.fn.strcharpart(remaining, 0, i)
+			if vim.fn.strdisplaywidth(segment) > max_width then
+				break
+			end
+			hard_cut = i
+			if vim.fn.strcharpart(remaining, i - 1, 1) == " " then
+				cut = i
+			end
+		end
+
+		if not cut then
+			-- No space found, so hard-break at max_width.
+			cut = math.max(hard_cut, 1)
+		end
+
+		table.insert(result, vim.fn.strcharpart(remaining, 0, cut))
+		remaining = vim.fn.strcharpart(remaining, cut)
+	end
+
+	if #remaining > 0 then
+		table.insert(result, remaining)
+	end
+
+	return result
+end
+
+--- Build virtual lines for a boxed annotation displayed above the target line
+---@param note string The annotation text (may contain newlines)
+---@param prefix string Text to display before the first line (e.g. icon)
+---@param hl_group string Highlight group for the content
+---@param border_hl string Highlight group for the box border
+---@param wrap_at number Max content width before wrapping
+---@return table virt_lines Array of virtual line chunks for nvim_buf_set_extmark
+local function build_box_lines(note, prefix, hl_group, border_hl, wrap_at)
+	-- Split on literal "\n" (backslash-n typed into vim.fn.input) and real newlines
+	local lines = vim.split(note:gsub("\\n", "\n"), "\n")
+	local prefix_width = vim.fn.strdisplaywidth(prefix)
+	local indent = string.rep(" ", prefix_width)
+
+	-- 2 border chars (│…│) + 1 trailing padding take display space from wrap_at
+	local max_content_width = math.max((tonumber(wrap_at) or 80) - 3, 1)
+
+	local content = {}
+	local max_width = 0
+
+	for i, line in ipairs(lines) do
+		local full_line = i == 1 and (prefix .. line) or (indent .. line)
+		local wrapped = wrap_text(full_line, max_content_width)
+		table.insert(content, wrapped[1])
+		local w = vim.fn.strdisplaywidth(wrapped[1])
+		if w > max_width then
+			max_width = w
+		end
+		for j = 2, #wrapped do
+			local continuation = indent .. wrapped[j]
+			local cw = vim.fn.strdisplaywidth(continuation)
+			if cw > max_content_width then
+				local rewrapped = wrap_text(continuation, max_content_width)
+				for _, rwl in ipairs(rewrapped) do
+					local rw = vim.fn.strdisplaywidth(rwl)
+					if rw > max_width then
+						max_width = rw
+					end
+					table.insert(content, rwl)
+				end
+			else
+				if cw > max_width then
+					max_width = cw
+				end
+				table.insert(content, continuation)
+			end
+		end
+	end
+
+	local inner_width = max_content_width + 1
+	local virt_lines = {}
+
+	-- Top border
+	table.insert(virt_lines, {
+		{ "╭" .. string.rep("─", inner_width) .. "╮", border_hl },
+	})
+
+	-- Body rows
+	for _, text in ipairs(content) do
+		local fill = inner_width - vim.fn.strdisplaywidth(text)
+		table.insert(virt_lines, {
+			{ "│", border_hl },
+			{ text .. string.rep(" ", fill), hl_group },
+			{ "│", border_hl },
+		})
+	end
+
+	-- Bottom border
+	table.insert(virt_lines, {
+		{ "╰" .. string.rep("─", inner_width) .. "╯", border_hl },
+	})
+
+	return virt_lines
+end
+
 --- Show annotation as virtual text at the end of a line
 ---@param bufnr number Buffer number
 ---@param line number 1-based line number
@@ -137,13 +267,29 @@ function M.show_annotation(bufnr, line, note)
 	end
 
 	local cfg = config.get()
-	-- some guards
 	local hl_group = cfg.virt_text_hl or "HauntAnnotation"
 	local prefix = cfg.annotation_prefix or "  "
 	local suffix = cfg.annotation_suffix or ""
 	local virt_text_pos = cfg.virt_text_pos or "eol"
 
-	-- nvim_buf_set_extmark uses 0-based line numbers
+	if virt_text_pos == "above" then
+		local max_width = cfg.above_max_width or 80
+		local text_width = max_width
+		local win = vim.fn.bufwinid(bufnr)
+		if win ~= -1 then
+			local info = vim.fn.getwininfo(win)[1]
+			text_width = math.min(max_width, info.width - info.textoff)
+		end
+		local box_lines = build_box_lines(note .. suffix, prefix, hl_group, "HauntAnnotationBorder", text_width)
+		-- virt_lines_above on row 0 is invisible (Neovim clips virtual lines
+		-- above the window topline). Fall back to placing below line 1.
+		local extmark_id = vim.api.nvim_buf_set_extmark(bufnr, M.get_namespace(), line - 1, 0, {
+			virt_lines = box_lines,
+			virt_lines_above = line > 1,
+		})
+		return extmark_id
+	end
+
 	local extmark_id = vim.api.nvim_buf_set_extmark(bufnr, M.get_namespace(), line - 1, 0, {
 		virt_text = { { prefix .. note .. suffix, hl_group } },
 		virt_text_pos = virt_text_pos,

--- a/lua/haunt/display.lua
+++ b/lua/haunt/display.lua
@@ -206,10 +206,7 @@ local function resolve_border(spec, default_hl)
 		spec = BORDER_PRESETS.rounded
 	elseif 8 % #spec ~= 0 then
 		vim.notify(
-			string.format(
-				"haunt.nvim: above_border array length %d does not divide 8, falling back to 'rounded'",
-				#spec
-			),
+			string.format("haunt.nvim: above_border array length %d does not divide 8, falling back to 'rounded'", #spec),
 			vim.log.levels.WARN
 		)
 		spec = BORDER_PRESETS.rounded
@@ -254,28 +251,29 @@ local function build_box_lines(note, prefix, hl_group, border, wrap_at)
 		local full_line = i == 1 and (prefix .. line) or (indent .. line)
 		local wrapped = wrap_text(full_line, max_content_width)
 		table.insert(content, wrapped[1])
-		local w = vim.fn.strdisplaywidth(wrapped[1])
-		if w > max_width then
-			max_width = w
+		local width = vim.fn.strdisplaywidth(wrapped[1])
+		if width > max_width then
+			max_width = width
 		end
 		for j = 2, #wrapped do
 			local continuation = indent .. wrapped[j]
-			local cw = vim.fn.strdisplaywidth(continuation)
-			if cw > max_content_width then
-				local rewrapped = wrap_text(continuation, max_content_width)
-				for _, rwl in ipairs(rewrapped) do
-					local rw = vim.fn.strdisplaywidth(rwl)
-					if rw > max_width then
-						max_width = rw
-					end
-					table.insert(content, rwl)
-				end
-			else
-				if cw > max_width then
-					max_width = cw
+			local content_width = vim.fn.strdisplaywidth(continuation)
+			if content_width <= max_content_width then
+				if content_width > max_width then
+					max_width = content_width
 				end
 				table.insert(content, continuation)
+				goto continue
 			end
+			local rewrapped = wrap_text(continuation, max_content_width)
+			for _, rwl in ipairs(rewrapped) do
+				local rw = vim.fn.strdisplaywidth(rwl)
+				if rw > max_width then
+					max_width = rw
+				end
+				table.insert(content, rwl)
+			end
+			::continue::
 		end
 	end
 

--- a/lua/haunt/init.lua
+++ b/lua/haunt/init.lua
@@ -307,6 +307,16 @@ function M.setup_autocmds()
 		end,
 		desc = "Auto-save all bookmarks before Vim exits",
 	})
+
+	vim.api.nvim_create_autocmd({ "VimResized", "WinResized" }, {
+		group = augroup,
+		callback = function()
+			vim.schedule(function()
+				require("haunt.api").refresh_above_annotations()
+			end)
+		end,
+		desc = "Re-wrap above annotations to fit new window width",
+	})
 end
 
 --- Setup function for haunt.nvim.

--- a/tests/display_spec.lua
+++ b/tests/display_spec.lua
@@ -201,9 +201,10 @@ describe("haunt.display", function()
 
 			-- top border + 1 body row + bottom border = 3
 			assert.are.equal(3, #virt_lines)
-			-- Top border is a single chunk
-			assert.are.equal(1, #virt_lines[1])
-			assert.are.equal("╭", string.sub(virt_lines[1][1][1], 1, #"╭"))
+			-- Top border is 3 chunks: corner + edge + corner
+			assert.are.equal(3, #virt_lines[1])
+			assert.are.equal("╭", virt_lines[1][1][1])
+			assert.are.equal("╮", virt_lines[1][3][1])
 			-- Body row has border + content (padded to full width) + border
 			assert.are.equal("│", virt_lines[2][1][1])
 			assert.is_true(vim.startswith(virt_lines[2][2][1], "> fix this"))
@@ -256,7 +257,10 @@ describe("haunt.display", function()
 			-- Should have more than 3 lines (top + multiple body rows + bottom)
 			assert.is_true(#virt_lines > 3)
 			-- All body rows must fit within the box width
-			local box_width = vim.fn.strdisplaywidth(virt_lines[1][1][1])
+			local box_width = 0
+			for _, chunk in ipairs(virt_lines[1]) do
+				box_width = box_width + vim.fn.strdisplaywidth(chunk[1])
+			end
 			for i = 2, #virt_lines - 1 do
 				local row_width = 0
 				for _, chunk in ipairs(virt_lines[i]) do
@@ -323,6 +327,146 @@ describe("haunt.display", function()
 				end
 			end
 			assert.is_false(found)
+		end)
+
+		it("uses single border when above_border = 'single'", function()
+			config.setup({ virt_text_pos = "above", annotation_prefix = "> ", above_border = "single" })
+
+			local extmark_id = display.show_annotation(bufnr, 2, "note")
+
+			local ns = display.get_namespace()
+			local details = vim.api.nvim_buf_get_extmark_by_id(bufnr, ns, extmark_id, { details = true })
+			local virt_lines = details[3].virt_lines
+
+			assert.are.equal("┌", virt_lines[1][1][1])
+			assert.are.equal("┐", virt_lines[1][3][1])
+			assert.are.equal("│", virt_lines[2][1][1])
+			assert.are.equal("│", virt_lines[2][3][1])
+			local last = virt_lines[#virt_lines]
+			assert.are.equal("└", last[1][1])
+			assert.are.equal("┘", last[3][1])
+		end)
+
+		it("uses double border when above_border = 'double'", function()
+			config.setup({ virt_text_pos = "above", annotation_prefix = "> ", above_border = "double" })
+
+			local extmark_id = display.show_annotation(bufnr, 2, "note")
+
+			local ns = display.get_namespace()
+			local details = vim.api.nvim_buf_get_extmark_by_id(bufnr, ns, extmark_id, { details = true })
+			local virt_lines = details[3].virt_lines
+
+			assert.are.equal("╔", virt_lines[1][1][1])
+			assert.are.equal("╗", virt_lines[1][3][1])
+			assert.are.equal("║", virt_lines[2][1][1])
+			assert.are.equal("║", virt_lines[2][3][1])
+		end)
+
+		it("accepts custom 8-element border array", function()
+			config.setup({
+				virt_text_pos = "above",
+				annotation_prefix = "> ",
+				above_border = { "+", "-", "+", "|", "+", "-", "+", "|" },
+			})
+
+			local extmark_id = display.show_annotation(bufnr, 2, "note")
+
+			local ns = display.get_namespace()
+			local details = vim.api.nvim_buf_get_extmark_by_id(bufnr, ns, extmark_id, { details = true })
+			local virt_lines = details[3].virt_lines
+
+			assert.are.equal("+", virt_lines[1][1][1])
+			assert.are.equal("+", virt_lines[1][3][1])
+			assert.are.equal("|", virt_lines[2][1][1])
+			assert.are.equal("|", virt_lines[2][3][1])
+			local last = virt_lines[#virt_lines]
+			assert.are.equal("+", last[1][1])
+			assert.are.equal("+", last[3][1])
+		end)
+
+		it("accepts border elements with highlight groups", function()
+			config.setup({
+				virt_text_pos = "above",
+				annotation_prefix = "> ",
+				above_border = {
+					{ "╭", "Special" },
+					{ "─", "Title" },
+					{ "╮", "Special" },
+					{ "│", "Comment" },
+					{ "╯", "Special" },
+					{ "─", "Title" },
+					{ "╰", "Special" },
+					{ "│", "Comment" },
+				},
+			})
+
+			local extmark_id = display.show_annotation(bufnr, 2, "note")
+
+			local ns = display.get_namespace()
+			local details = vim.api.nvim_buf_get_extmark_by_id(bufnr, ns, extmark_id, { details = true })
+			local virt_lines = details[3].virt_lines
+
+			-- Top border: corner hl distinct from edge hl
+			assert.are.equal("Special", virt_lines[1][1][2])
+			assert.are.equal("Title", virt_lines[1][2][2])
+			assert.are.equal("Special", virt_lines[1][3][2])
+			-- Left/right borders use the side highlight
+			assert.are.equal("Comment", virt_lines[2][1][2])
+			assert.are.equal("Comment", virt_lines[2][3][2])
+		end)
+
+		it("renders empty border with above_border = 'none'", function()
+			config.setup({ virt_text_pos = "above", annotation_prefix = "> ", above_border = "none" })
+
+			local extmark_id = display.show_annotation(bufnr, 2, "note")
+
+			local ns = display.get_namespace()
+			local details = vim.api.nvim_buf_get_extmark_by_id(bufnr, ns, extmark_id, { details = true })
+			local virt_lines = details[3].virt_lines
+
+			assert.are.equal("", virt_lines[1][1][1])
+			assert.are.equal("", virt_lines[1][3][1])
+			assert.are.equal("", virt_lines[2][1][1])
+			assert.are.equal("", virt_lines[2][3][1])
+		end)
+
+		it("falls back to rounded for unknown preset strings", function()
+			config.setup({ virt_text_pos = "above", annotation_prefix = "> ", above_border = "shadow" })
+
+			local extmark_id = display.show_annotation(bufnr, 2, "note")
+
+			local ns = display.get_namespace()
+			local details = vim.api.nvim_buf_get_extmark_by_id(bufnr, ns, extmark_id, { details = true })
+			local virt_lines = details[3].virt_lines
+
+			assert.are.equal("╭", virt_lines[1][1][1])
+			assert.are.equal("│", virt_lines[2][1][1])
+		end)
+
+		it("falls back to rounded for array length that does not divide 8", function()
+			config.setup({ virt_text_pos = "above", annotation_prefix = "> ", above_border = { "a", "b", "c" } })
+
+			local extmark_id = display.show_annotation(bufnr, 2, "note")
+
+			local ns = display.get_namespace()
+			local details = vim.api.nvim_buf_get_extmark_by_id(bufnr, ns, extmark_id, { details = true })
+			local virt_lines = details[3].virt_lines
+
+			assert.are.equal("╭", virt_lines[1][1][1])
+			assert.are.equal("│", virt_lines[2][1][1])
+		end)
+
+		it("falls back to rounded for empty table", function()
+			config.setup({ virt_text_pos = "above", annotation_prefix = "> ", above_border = {} })
+
+			local extmark_id = display.show_annotation(bufnr, 2, "note")
+
+			local ns = display.get_namespace()
+			local details = vim.api.nvim_buf_get_extmark_by_id(bufnr, ns, extmark_id, { details = true })
+			local virt_lines = details[3].virt_lines
+
+			assert.are.equal("╭", virt_lines[1][1][1])
+			assert.are.equal("│", virt_lines[2][1][1])
 		end)
 	end)
 

--- a/tests/display_spec.lua
+++ b/tests/display_spec.lua
@@ -150,6 +150,182 @@ describe("haunt.display", function()
 		end)
 	end)
 
+	describe("annotation with virt_text_pos = above", function()
+		local bufnr
+
+		before_each(function()
+			bufnr = vim.api.nvim_create_buf(false, true)
+			vim.api.nvim_buf_set_lines(bufnr, 0, -1, false, { "Line 1", "Line 2", "Line 3" })
+		end)
+
+		after_each(function()
+			if bufnr and vim.api.nvim_buf_is_valid(bufnr) then
+				vim.api.nvim_buf_delete(bufnr, { force = true })
+			end
+		end)
+
+		it("creates extmark with virt_lines above the line", function()
+			config.setup({ virt_text_pos = "above", annotation_prefix = "> " })
+
+			local extmark_id = display.show_annotation(bufnr, 2, "Test note")
+			assert.is_number(extmark_id)
+
+			local ns = display.get_namespace()
+			local details = vim.api.nvim_buf_get_extmark_by_id(bufnr, ns, extmark_id, { details = true })
+
+			assert.is_not_nil(details[3].virt_lines)
+			assert.is_true(details[3].virt_lines_above)
+		end)
+
+		it("places virt_lines below line 1 (above row 0 is clipped by Neovim)", function()
+			config.setup({ virt_text_pos = "above", annotation_prefix = "> " })
+
+			local extmark_id = display.show_annotation(bufnr, 1, "first line note")
+			assert.is_number(extmark_id)
+
+			local ns = display.get_namespace()
+			local details = vim.api.nvim_buf_get_extmark_by_id(bufnr, ns, extmark_id, { details = true })
+
+			assert.is_not_nil(details[3].virt_lines)
+			assert.is_false(details[3].virt_lines_above)
+		end)
+
+		it("renders single-line note as top + body + bottom", function()
+			config.setup({ virt_text_pos = "above", annotation_prefix = "> " })
+
+			local extmark_id = display.show_annotation(bufnr, 2, "fix this")
+
+			local ns = display.get_namespace()
+			local details = vim.api.nvim_buf_get_extmark_by_id(bufnr, ns, extmark_id, { details = true })
+			local virt_lines = details[3].virt_lines
+
+			-- top border + 1 body row + bottom border = 3
+			assert.are.equal(3, #virt_lines)
+			-- Top border is a single chunk
+			assert.are.equal(1, #virt_lines[1])
+			assert.are.equal("╭", string.sub(virt_lines[1][1][1], 1, #"╭"))
+			-- Body row has border + content (padded to full width) + border
+			assert.are.equal("│", virt_lines[2][1][1])
+			assert.is_true(vim.startswith(virt_lines[2][2][1], "> fix this"))
+			assert.are.equal("│", virt_lines[2][3][1])
+		end)
+
+		it("renders multi-line note with multiple body rows", function()
+			config.setup({ virt_text_pos = "above", annotation_prefix = "> " })
+
+			local extmark_id = display.show_annotation(bufnr, 2, "line one\nline two")
+
+			local ns = display.get_namespace()
+			local details = vim.api.nvim_buf_get_extmark_by_id(bufnr, ns, extmark_id, { details = true })
+			local virt_lines = details[3].virt_lines
+
+			-- top border + 2 body rows + bottom border = 4
+			assert.are.equal(4, #virt_lines)
+			-- Body rows
+			assert.are.equal("│", virt_lines[2][1][1])
+			assert.are.equal("│", virt_lines[2][3][1])
+			assert.are.equal("│", virt_lines[3][1][1])
+			assert.are.equal("│", virt_lines[3][3][1])
+		end)
+
+		it("splits literal backslash-n as line breaks", function()
+			config.setup({ virt_text_pos = "above", annotation_prefix = "> " })
+
+			local extmark_id = display.show_annotation(bufnr, 1, "first\\nsecond")
+
+			local ns = display.get_namespace()
+			local details = vim.api.nvim_buf_get_extmark_by_id(bufnr, ns, extmark_id, { details = true })
+			local virt_lines = details[3].virt_lines
+
+			-- top + 2 body rows + bottom = 4
+			assert.are.equal(4, #virt_lines)
+			assert.is_true(vim.startswith(virt_lines[2][2][1], "> first"))
+			assert.is_true(vim.startswith(virt_lines[3][2][1], "  second"))
+		end)
+
+		it("wraps long text at above_max_width boundary", function()
+			config.setup({ virt_text_pos = "above", annotation_prefix = "> ", above_max_width = 20 })
+
+			-- "> hello world foo bar" is 21 display cols, should wrap
+			local extmark_id = display.show_annotation(bufnr, 1, "hello world foo bar")
+
+			local ns = display.get_namespace()
+			local details = vim.api.nvim_buf_get_extmark_by_id(bufnr, ns, extmark_id, { details = true })
+			local virt_lines = details[3].virt_lines
+
+			-- Should have more than 3 lines (top + multiple body rows + bottom)
+			assert.is_true(#virt_lines > 3)
+			-- All body rows must fit within the box width
+			local box_width = vim.fn.strdisplaywidth(virt_lines[1][1][1])
+			for i = 2, #virt_lines - 1 do
+				local row_width = 0
+				for _, chunk in ipairs(virt_lines[i]) do
+					row_width = row_width + vim.fn.strdisplaywidth(chunk[1])
+				end
+				assert.are.equal(box_width, row_width)
+			end
+		end)
+
+		it("does not wrap short text", function()
+			config.setup({ virt_text_pos = "above", annotation_prefix = "> ", above_max_width = 80 })
+
+			local extmark_id = display.show_annotation(bufnr, 1, "short")
+
+			local ns = display.get_namespace()
+			local details = vim.api.nvim_buf_get_extmark_by_id(bufnr, ns, extmark_id, { details = true })
+			local virt_lines = details[3].virt_lines
+
+			-- top + 1 body + bottom = 3
+			assert.are.equal(3, #virt_lines)
+		end)
+
+		it("includes annotation suffix", function()
+			config.setup({
+				virt_text_pos = "above",
+				annotation_prefix = "> ",
+				annotation_suffix = "!",
+			})
+
+			local extmark_id = display.show_annotation(bufnr, 1, "fix this")
+
+			local ns = display.get_namespace()
+			local details = vim.api.nvim_buf_get_extmark_by_id(bufnr, ns, extmark_id, { details = true })
+			local virt_lines = details[3].virt_lines
+
+			assert.is_true(vim.startswith(virt_lines[2][2][1], "> fix this!"))
+		end)
+
+		it("handles tiny above_max_width values without hanging", function()
+			config.setup({ virt_text_pos = "above", annotation_prefix = "> ", above_max_width = 1 })
+
+			local extmark_id = display.show_annotation(bufnr, 1, "unbroken")
+
+			local ns = display.get_namespace()
+			local details = vim.api.nvim_buf_get_extmark_by_id(bufnr, ns, extmark_id, { details = true })
+			local virt_lines = details[3].virt_lines
+
+			assert.is_true(#virt_lines > 3)
+		end)
+
+		it("can be hidden like regular annotations", function()
+			config.setup({ virt_text_pos = "above" })
+
+			local extmark_id = display.show_annotation(bufnr, 2, "note")
+			local ok = display.hide_annotation(bufnr, extmark_id)
+			assert.is_true(ok)
+
+			local ns = display.get_namespace()
+			local extmarks = vim.api.nvim_buf_get_extmarks(bufnr, ns, 0, -1, {})
+			local found = false
+			for _, mark in ipairs(extmarks) do
+				if mark[1] == extmark_id then
+					found = true
+				end
+			end
+			assert.is_false(found)
+		end)
+	end)
+
 	describe("set_bookmark_mark / get_extmark_line / delete_bookmark_mark", function()
 		local bufnr
 


### PR DESCRIPTION
## Checklist
- [x] Read `CONTRIBUTING.md`
- [x] Ran tests (`./scripts/test`) locally
- [x] Formatted with Stylua
- [x] Added tests if necessary
- [x] Updated documentation(inline to source code) if applicable
- [x] Updated `README.md` if applicable

## Summary

Adds a new `virt_text_pos = "above"` annotation display mode that renders bookmark notes as boxed virtual lines above the target line. I missed this because I like to have longer annotations and to just have them in a box above the code. This way I can use this for code-reviews for example. Hope it's not outside of the plugin's scope.

- Configurable above_wrap_at width for wrapping boxed annotations.
- New border highlight group linked to FloatBorder.
- Support for multiline notes and literal `\n` input.
- Existing annotation_prefix, annotation_suffix, and virt_text_hl behavior preserved.
- Tests covering rendering, wrapping, suffix support, and cleanup.

## Screenshot:

<img width="882" height="897" alt="Screenshot 2026-05-17 at 21 38 50" src="https://github.com/user-attachments/assets/4e70c3a6-5317-461e-abd1-c721e676d781" />
