### PR TITLE
Don't create data_dir unnecessarily when switching directories

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,13 @@
 # Changelog
 
+## [1.3.0](https://github.com/TheNoeTrevino/haunt.nvim/compare/v1.2.1...v1.3.0) (2026-06-07)
+
+
+### Features
+
+* above borders config options, demo to readme ([2acc045](https://github.com/TheNoeTrevino/haunt.nvim/commit/2acc045e45e04abbe6991ffebb0b67a63eb91126))
+* add above-annotations ([27881a4](https://github.com/TheNoeTrevino/haunt.nvim/commit/27881a4824e65531fef88e09500658dd8cba82c2))
+
 ## [1.2.1](https://github.com/TheNoeTrevino/haunt.nvim/compare/v1.2.0...v1.2.1) (2026-05-22)
 
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## [1.2.1](https://github.com/TheNoeTrevino/haunt.nvim/compare/v1.2.0...v1.2.1) (2026-05-22)
+
+
+### Bug Fixes
+
+* not getting bookmarks at line ([77f41c5](https://github.com/TheNoeTrevino/haunt.nvim/commit/77f41c502a85daed76af253276409fed4fd5bff7))
+
 ## [1.2.0](https://github.com/TheNoeTrevino/haunt.nvim/compare/v1.1.0...v1.2.0) (2026-05-11)
 
 

--- a/lua/haunt/api.lua
+++ b/lua/haunt/api.lua
@@ -1028,7 +1028,7 @@ function M.change_data_dir(new_dir)
 	---@cast persistence -nil
 	---@cast hooks -nil
 
-	local old_dir = persistence.ensure_data_dir()
+	local old_dir = persistence.get_data_dir()
 
 	store.save()
 	persistence.set_data_dir(new_dir)

--- a/lua/haunt/persistence.lua
+++ b/lua/haunt/persistence.lua
@@ -21,6 +21,7 @@
 
 ---@class PersistenceModule
 ---@field set_data_dir fun(dir: string|nil)
+---@field get_data_dir fun(): string
 ---@field ensure_data_dir fun(): string|nil, string|nil
 ---@field get_git_info fun(): {root: string|nil, branch: string|nil}
 ---@field get_storage_path fun(): string
@@ -70,8 +71,9 @@ function M.set_data_dir(dir)
 	custom_data_dir = expanded
 end
 
+--- Get the current data directory path without creating it.
 ---@return string data_dir The haunt data directory path
-local function get_data_dir()
+function M.get_data_dir()
 	local config = require("haunt.config")
 	return custom_data_dir or config.DEFAULT_DATA_DIR
 end
@@ -79,7 +81,7 @@ end
 --- Ensures the haunt data directory exists
 ---@return string data_dir The haunt data directory path
 function M.ensure_data_dir()
-	local data_dir = get_data_dir()
+	local data_dir = M.get_data_dir()
 	vim.fn.mkdir(data_dir, "p")
 	return data_dir
 end
@@ -87,7 +89,7 @@ end
 ---@param key string Pre-built keying string to hash into the filename
 ---@return string path
 local function path_for_key(key)
-	return get_data_dir() .. vim.fn.sha256(key):sub(1, 12) .. ".json"
+	return M.get_data_dir() .. vim.fn.sha256(key):sub(1, 12) .. ".json"
 end
 
 --- Generates a storage path for the current project and branch.

--- a/tests/change_data_dir_spec.lua
+++ b/tests/change_data_dir_spec.lua
@@ -422,6 +422,20 @@ describe("change_data_dir", function()
 				assert.are.equal(config.DEFAULT_DATA_DIR, persistence.ensure_data_dir())
 			end)
 
+			it("does not create the old data_dir when switching away with no bookmarks", function()
+				bufnr, test_file = helpers.create_test_buffer({ "Line 1" })
+
+				local untouched_dir = vim.fn.tempname() .. "_haunt_untouched/"
+				persistence.set_data_dir(untouched_dir)
+				assert.are.equal(0, vim.fn.isdirectory(untouched_dir))
+
+				api.change_data_dir(data_dir_2)
+
+				assert.are.equal(0, vim.fn.isdirectory(untouched_dir))
+
+				helpers.cleanup_temp_dir(untouched_dir)
+			end)
+
 			it("handles multiple loaded buffers", function()
 				local bufnr1, test_file1 = helpers.create_test_buffer({ "File 1 Line 1", "File 1 Line 2" })
 				local bufnr2, test_file2 = helpers.create_test_buffer({ "File 2 Line 1", "File 2 Line 2" })

--- a/tests/persistence_spec.lua
+++ b/tests/persistence_spec.lua
@@ -280,6 +280,28 @@ describe("haunt.persistence", function()
 		end)
 	end)
 
+	describe("get_data_dir", function()
+		after_each(function()
+			persistence.set_data_dir(nil)
+		end)
+
+		it("returns the default data dir when no custom dir is set", function()
+			local config = require("haunt.config")
+			assert.are.equal(config.DEFAULT_DATA_DIR, persistence.get_data_dir())
+		end)
+
+		it("returns the custom data dir without creating it", function()
+			local temp_dir = vim.fn.tempname() .. "_haunt_get/"
+			persistence.set_data_dir(temp_dir)
+
+			assert.are.equal(0, vim.fn.isdirectory(temp_dir))
+			assert.are.equal(temp_dir, persistence.get_data_dir())
+			assert.are.equal(0, vim.fn.isdirectory(temp_dir))
+
+			vim.fn.delete(temp_dir, "rf")
+		end)
+	end)
+
 	describe("create_bookmark", function()
 		it("creates bookmark with all fields", function()
 			local bookmark = persistence.create_bookmark("/tmp/test.lua", 42, "Test note")


### PR DESCRIPTION
## Checklist
- [x] Read `CONTRIBUTING.md`
- [x] Ran tests (`./scripts/test`) locally
- [x] Formatted with Stylua
- [x] Added tests if necessary
- [x] Updated documentation(inline to source code) if applicable
- [x] Updated `README.md` if applicable

## Summary
`api.change_data_dir()` called `persistence.ensure_data_dir()` just to read the old directory path for the `data_dir_change` hook, but `ensure_data_dir()` unconditionally does `mkdir -ps` the directory as a side effect.

  * Made `get_data_dir()` function public
  * Made `change_data_dir()` use it instead of `ensure_data_dir()`
  * Actual `save_bookmarks` -> `build_save_payload` -> `ensure_data_dir()` remains unchanged
  * Added tests