### PR TITLE
Bugfix 99/quickfix usees extmark bookmarks

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,22 +1,24 @@
 # Contributing
 
-First of all, thank you for considering contributing to this project! 
+First of all, thank you for considering contributing to this project!
 
 ## Git Workflow
 
 1. Fork the repository
 2. Create your feature/bugfix branch: `git checkout -b feature-123/your-feature`
-  a. The 123 numbers should represent the issue you are working on. 
+   a. The 123 numbers should represent the issue you are working on.
 3. When committing, use the [conventional commit format](https://www.conventionalcommits.org/en/v1.0.0/).
-  - You can use the `git log` for examples of previous commit messages.
-  - Please try to have an understandable and followable commit history, open a new branch (don't PR changes from your main to the repository's main).
+
+- You can use the `git log` for examples of previous commit messages.
+- Please try to have an understandable and followable commit history, open a new branch (don't PR changes from your main to the repository's main).
+
 4. Open a PR to main
 
 ## Config for Local Development
 
-Point to your local clone, this is with lazy.nvim: 
+Point to your local clone, this is with lazy.nvim:
 
-``` lua
+```lua
 return {
   dir = "~/haunt.nvim",
   ---@class HauntConfig
@@ -41,11 +43,11 @@ return {
 
 `project.lua` - Project root, branch, and project-id detection, with cached git lookups/logic.
 
-`picker.lua` - Picker integrations, currently that is [snacks.nvim](https://github.com/folke/snacks.nvim) and [telescope](https://github.com/nvim-telescope/telescope.nvim). We have each picker implement the `PickerModule` interface. This makes referencing the different picker much easier, and only gives us what we need. Unfortunately, each picker has a different `opts` structure. Which means we can't really type the `opts` well in `picker.show(opts?)`. Oh well. 
+`picker.lua` - Picker integrations, currently that is [snacks.nvim](https://github.com/folke/snacks.nvim) and [telescope](https://github.com/nvim-telescope/telescope.nvim). We have each picker implement the `PickerModule` interface. This makes referencing the different picker much easier, and only gives us what we need. Unfortunately, each picker has a different `opts` structure. Which means we can't really type the `opts` well in `picker.show(opts?)`. Oh well.
 
 `store.lua` - In memory operations on bookmarks
 
-`sidekick.lua` - [Sidekick.nvim](https://github.com/folke/sidekick.nvim) integration 
+`sidekick.lua` - [Sidekick.nvim](https://github.com/folke/sidekick.nvim) integration
 
 `restoration.lua` - Restoring annotations on buffer load
 
@@ -55,12 +57,31 @@ return {
 
 Adhere to these separations as much as possible.
 
-## Testing 
+## Bookmark Positions: Read Through the Funnel
+
+A bookmark's line number lives in two places, and they disagree:
+
+- The **extmark** in the buffer is the truth while that buffer is loaded. Neovim
+  moves it for you on every edit.
+- `bookmark.line` is a **snapshot**. It is only authoritative for persistence and
+  for buffers that aren't loaded (no extmark to ask).
+
+So if you read `bookmark.line` straight off the store, you get wherever the
+bookmark was when it was created, not where it is now. This was the cause of #72, #92, and
+#99
+
+The fix is `synced_bookmarks()` in `store.lua`. It is private, it loads and
+syncs from extmarks unconditionally, and **every** public accessor goes through
+it. If you're adding a getter to the store, read from `synced_bookmarks()` please, not
+from the `bookmarks` array.
+
+## Testing
 
 If you are making significant changes, please consider adding tests.
 We use [busted](https://github.com/lunarmodules/busted) for testing.
 
 To run tests locally, you can use:
+
 ```bash
 ./scripts/test
 ```

--- a/lua/haunt/api.lua
+++ b/lua/haunt/api.lua
@@ -586,14 +586,15 @@ function M.clear()
 		return false
 	end
 
-	-- Get bookmarks before clearing for visual cleanup
-	local bookmarks = store.get_all_raw()
-	local file_bookmarks = {}
-	for _, bookmark in ipairs(bookmarks) do
-		if bookmark.file == current_file then
-			table.insert(file_bookmarks, bookmark)
-		end
-	end
+	-- Live store references, not copies: the visual cleanup and delete hooks
+	-- below need identity with the stored bookmarks.
+	local file_bookmarks = vim
+		.iter(store.get_all_raw())
+		---@param bookmark Bookmark
+		:filter(function(bookmark)
+			return bookmark.file == current_file
+		end)
+		:totable()
 
 	-- early return for no bookmarks
 	if #file_bookmarks == 0 then
@@ -740,7 +741,7 @@ function M.delete_by_id(bookmark_id)
 	---@cast store -nil
 	---@cast hooks -nil
 
-	local bookmark, _ = store.find_by_id(bookmark_id)
+	local bookmark = store.find_by_id(bookmark_id)
 	if not bookmark then
 		vim.notify("haunt.nvim: Bookmark not found", vim.log.levels.WARN)
 		return false

--- a/lua/haunt/sidekick.lua
+++ b/lua/haunt/sidekick.lua
@@ -72,13 +72,13 @@ function M.get_locations(opts)
 	-- Filter to current buffer if requested
 	if current_buffer then
 		local current_file = vim.fn.fnamemodify(vim.api.nvim_buf_get_name(0), ":p")
-		local filtered = {}
-		for _, bookmark in ipairs(bookmarks) do
-			if bookmark.file == current_file then
-				table.insert(filtered, bookmark)
-			end
-		end
-		bookmarks = filtered
+		bookmarks = vim
+			.iter(bookmarks)
+			---@param bookmark Bookmark
+			:filter(function(bookmark)
+				return bookmark.file == current_file
+			end)
+			:totable()
 	end
 
 	-- If no bookmarks after filtering, return empty string
@@ -95,18 +95,21 @@ function M.get_locations(opts)
 	end)
 
 	-- Format each bookmark
-	local lines = {}
-	for _, bookmark in ipairs(bookmarks) do
-		local relative_path = to_relative_path(bookmark.file)
-		local line_str = string.format("- @/%s :L%d", relative_path, bookmark.line)
+	local lines = vim
+		.iter(bookmarks)
+		---@param bookmark Bookmark
+		:map(function(bookmark)
+			local relative_path = to_relative_path(bookmark.file)
+			local line_str = string.format("- @/%s :L%d", relative_path, bookmark.line)
 
-		-- Append annotation if requested and exists
-		if append_annotations and bookmark.note and bookmark.note ~= "" then
-			line_str = line_str .. string.format(' - "%s"', bookmark.note)
-		end
+			-- Append annotation if requested and exists
+			if append_annotations and bookmark.note and bookmark.note ~= "" then
+				line_str = line_str .. string.format(' - "%s"', bookmark.note)
+			end
 
-		table.insert(lines, line_str)
-	end
+			return line_str
+		end)
+		:totable()
 
 	return table.concat(lines, "\n")
 end

--- a/lua/haunt/store.lua
+++ b/lua/haunt/store.lua
@@ -235,13 +235,36 @@ function M.get_bookmark_at_line(filepath, line)
 	return nil, nil
 end
 
---- Get sorted bookmarks for a specific file
---- O(1) lookup from file-based index (already sorted)
+--- Get bookmarks for a specific file, sorted by their current line.
+---
+--- `bookmarks_by_file` gives an O(k) membership lookup for the file, but its
+--- *order* cannot be trusted: it is a binary insert keyed on line-at-insert-time
+--- and is only rebuilt on load, while `sync_lines_from_extmarks` reassigns
+--- `bookmark.line` in place as text is edited. The index holds references to the
+--- same tables, so synced values show through — the ordering does not. Navigation
+--- (`[h` / `]h`) scans for the first bookmark past the cursor and needs ascending
+--- order, so sort after syncing.
+---
+--- Returns a fresh array of live bookmark references (not copies) — callers pass
+--- them straight to hooks, which expect identity with the stored bookmark.
 ---@param filepath string The normalized file path
----@return Bookmark[] bookmarks Sorted array of bookmarks for the file
+---@return Bookmark[] bookmarks Array of bookmarks for the file, sorted by line
 function M.get_sorted_bookmarks_for_file(filepath)
 	ensure_loaded()
-	return bookmarks_by_file[filepath] or {}
+
+	local file_bookmarks = bookmarks_by_file[filepath]
+	if not file_bookmarks or #file_bookmarks == 0 then
+		return {}
+	end
+
+	sync_lines_from_extmarks()
+
+	local sorted = vim.list_slice(file_bookmarks, 1, #file_bookmarks)
+	table.sort(sorted, function(a, b)
+		return a.line < b.line
+	end)
+
+	return sorted
 end
 
 --- Get all bookmarks as a deep copy.

--- a/lua/haunt/store.lua
+++ b/lua/haunt/store.lua
@@ -5,7 +5,7 @@
 ---@field reload fun()
 ---@field save fun(): boolean
 ---@field get_quickfix_items fun(opts?: QuickfixOpts): QuickfixItem[]
----@field find_by_id fun(bookmark_id: string): Bookmark|nil, number|nil
+---@field find_by_id fun(bookmark_id: string): Bookmark|nil
 ---@field get_bookmark_at_line fun(filepath: string, line: number): Bookmark|nil, number|nil
 ---@field get_sorted_bookmarks_for_file fun(filepath: string): Bookmark[]
 ---@field add_bookmark fun(bookmark: Bookmark)
@@ -156,14 +156,11 @@ end
 --- Find a bookmark by its ID
 ---@param bookmark_id string The unique ID of the bookmark to find
 ---@return Bookmark|nil bookmark The bookmark if found, nil otherwise
----@return number|nil index The index in the bookmarks array, nil if not found
 function M.find_by_id(bookmark_id)
-	for i, bm in ipairs(synced_bookmarks()) do
-		if bm.id == bookmark_id then
-			return bm, i
-		end
-	end
-	return nil, nil
+	---@param bookmark Bookmark
+	return vim.iter(synced_bookmarks()):find(function(bookmark)
+		return bookmark.id == bookmark_id
+	end)
 end
 
 --- Find a bookmark at a specific line in a file
@@ -177,13 +174,14 @@ function M.get_bookmark_at_line(filepath, line)
 		return nil, nil
 	end
 
-	for i, bookmark in ipairs(synced_bookmarks()) do
-		if bookmark.file == filepath and bookmark.line == line then
-			return bookmark, i
-		end
-	end
+	-- Iterate (index, bookmark) pairs so the index survives the pipeline;
+	-- `find` short-circuits on the first match and returns nil, nil otherwise.
+	---@param bookmark Bookmark
+	local i, found = vim.iter(ipairs(synced_bookmarks())):find(function(_, bookmark)
+		return bookmark.file == filepath and bookmark.line == line
+	end)
 
-	return nil, nil
+	return found, i
 end
 
 --- Get bookmarks for a specific file, sorted by their current line.
@@ -193,12 +191,13 @@ end
 ---@param filepath string The normalized file path
 ---@return Bookmark[] bookmarks Array of bookmarks for the file, sorted by line
 function M.get_sorted_bookmarks_for_file(filepath)
-	local file_bookmarks = {}
-	for _, bookmark in ipairs(synced_bookmarks()) do
-		if bookmark.file == filepath then
-			table.insert(file_bookmarks, bookmark)
-		end
-	end
+	local file_bookmarks = vim
+		.iter(synced_bookmarks())
+		---@param bookmark Bookmark
+		:filter(function(bookmark)
+			return bookmark.file == filepath
+		end)
+		:totable()
 
 	table.sort(file_bookmarks, function(a, b)
 		return a.line < b.line
@@ -229,32 +228,36 @@ function M.get_quickfix_items(opts)
 		append_annotations = true
 	end
 
-	local current_file = nil
+	local filter_to_current_file = nil
 	if opts.current_buffer then
-		current_file = utils.normalize_filepath(vim.api.nvim_buf_get_name(0))
-		if current_file == "" then
+		filter_to_current_file = utils.normalize_filepath(vim.api.nvim_buf_get_name(0))
+		if filter_to_current_file == "" then
 			return {}
 		end
 	end
 
 	-- Build plain items straight off the live references — nothing here
 	-- mutates a bookmark, and the items themselves are what get sorted.
-	local items = {}
-	for _, bookmark in ipairs(synced_bookmarks()) do
-		if not current_file or bookmark.file == current_file then
+	local items = vim
+		.iter(synced_bookmarks())
+		---@param bookmark Bookmark
+		:filter(function(bookmark)
+			return not filter_to_current_file or bookmark.file == filter_to_current_file
+		end)
+		---@param bookmark Bookmark
+		:map(function(bookmark)
 			local text = "Haunt bookmark"
 			if append_annotations and bookmark.note and bookmark.note ~= "" then
 				text = bookmark.note
 			end
-
-			table.insert(items, {
+			return {
 				filename = bookmark.file, -- absolute path works best for quickfix
 				lnum = bookmark.line,
 				col = 1,
 				text = text,
-			})
-		end
-	end
+			}
+		end)
+		:totable()
 
 	table.sort(items, function(a, b)
 		if a.filename == b.filename then

--- a/lua/haunt/store.lua
+++ b/lua/haunt/store.lua
@@ -261,8 +261,6 @@ end
 ---@param opts? QuickfixOpts Options for filtering and formatting
 ---@return QuickfixItem[] items Quickfix items
 function M.get_quickfix_items(opts)
-	ensure_loaded()
-
 	opts = opts or {}
 
 	local append_annotations = opts.append_annotations
@@ -272,11 +270,11 @@ function M.get_quickfix_items(opts)
 
 	local current_buffer = opts.current_buffer or false
 
-	-- Work on a copy to avoid mutating store order
-	local active_bookmarks = {}
-	for _, bookmark in ipairs(bookmarks) do
-		table.insert(active_bookmarks, bookmark)
-	end
+	-- Source from get_bookmarks() rather than reading `bookmarks` directly: it
+	-- syncs lines from extmarks first, so quickfix entries point at where a
+	-- bookmark is *now*, not where it was when it was created. The copy it
+	-- returns is also safe to sort without disturbing store order.
+	local active_bookmarks = M.get_bookmarks()
 
 	if current_buffer then
 		local current_file = utils.normalize_filepath(vim.api.nvim_buf_get_name(0))

--- a/lua/haunt/store.lua
+++ b/lua/haunt/store.lua
@@ -36,12 +36,15 @@ local M = {}
 local utils = require("haunt.utils")
 
 ---@private
+--- The in-memory bookmark array. `bookmark.line` in here is a SNAPSHOT: it is
+--- authoritative only for persistence and for buffers that aren't loaded (no
+--- extmark to ask). While a buffer is loaded, the tracking extmark is the
+--- source of truth for position. Nothing outside `synced_bookmarks()` and the
+--- load/save boundary may read `.line` from this table directly - every
+--- public accessor goes through `synced_bookmarks()` so it cannot observe stale
+--- lines
 ---@type Bookmark[]
 local bookmarks = {}
-
----@private
----@type table<string, Bookmark[]>
-local bookmarks_by_file = {}
 
 ---@private
 ---@type boolean
@@ -85,69 +88,6 @@ end
 local function ensure_hooks()
 	if not hooks then
 		hooks = require("haunt.hooks")
-	end
-end
-
---- Add a bookmark to the file-based index
---- Maintains sorted order by line number using binary search insertion
----@param bookmark Bookmark The bookmark to add to the index
-local function add_to_file_index(bookmark)
-	if not bookmarks_by_file[bookmark.file] then
-		bookmarks_by_file[bookmark.file] = {}
-	end
-
-	local file_bookmarks = bookmarks_by_file[bookmark.file]
-
-	-- Binary search to find insertion point
-	local left, right = 1, #file_bookmarks
-	local insert_pos = #file_bookmarks + 1
-
-	while left <= right do
-		local mid = math.floor((left + right) / 2)
-		if file_bookmarks[mid].line < bookmark.line then
-			left = mid + 1
-		else
-			insert_pos = mid
-			right = mid - 1
-		end
-	end
-
-	table.insert(file_bookmarks, insert_pos, bookmark)
-end
-
---- Remove a bookmark from the file-based index
----@param bookmark Bookmark The bookmark to remove from the index
-local function remove_from_file_index(bookmark)
-	local file_bookmarks = bookmarks_by_file[bookmark.file]
-	if not file_bookmarks then
-		return
-	end
-
-	for i, bm in ipairs(file_bookmarks) do
-		if bm.id == bookmark.id then
-			table.remove(file_bookmarks, i)
-			-- Clean up empty file entries
-			if #file_bookmarks == 0 then
-				bookmarks_by_file[bookmark.file] = nil
-			end
-			break
-		end
-	end
-end
-
---- Clear all bookmarks for a specific file from the index
----@param filepath string The file path to clear from the index
-local function clear_file_from_index(filepath)
-	bookmarks_by_file[filepath] = nil
-end
-
---- Rebuild the entire file-based index from the bookmarks array
---- This is called after loading bookmarks from persistence
-local function rebuild_file_index()
-	bookmarks_by_file = {}
-
-	for _, bookmark in ipairs(bookmarks) do
-		add_to_file_index(bookmark)
 	end
 end
 
@@ -197,13 +137,28 @@ local function sync_lines_from_extmarks()
 	end
 end
 
+--- THE read funnel. Every public accessor that exposes bookmarks (or anything
+--- derived from their positions) goes through here — it is the only place
+--- outside persistence allowed to touch the raw array. Loading and syncing
+--- happen unconditionally, so no caller can observe a stale `.line` and the
+--- #72/#92/#99 class of bug cannot be reintroduced by a new getter.
+---
+--- Returns the LIVE internal array: cheap, and several internal callers
+--- (restoration, display toggles, hooks) rely on reference identity with the
+--- stored bookmark. Accessors that hand data to plugin users must copy.
+---@return Bookmark[] bookmarks Live references, lines synced from extmarks
+local function synced_bookmarks()
+	ensure_loaded()
+	sync_lines_from_extmarks()
+	return bookmarks
+end
+
 --- Find a bookmark by its ID
 ---@param bookmark_id string The unique ID of the bookmark to find
 ---@return Bookmark|nil bookmark The bookmark if found, nil otherwise
 ---@return number|nil index The index in the bookmarks array, nil if not found
 function M.find_by_id(bookmark_id)
-	ensure_loaded()
-	for i, bm in ipairs(bookmarks) do
+	for i, bm in ipairs(synced_bookmarks()) do
 		if bm.id == bookmark_id then
 			return bm, i
 		end
@@ -217,16 +172,12 @@ end
 ---@return Bookmark|nil bookmark The bookmark at the line, or nil if none exists
 ---@return number|nil index The index of the bookmark in the bookmarks table
 function M.get_bookmark_at_line(filepath, line)
-	ensure_loaded()
-
 	-- If file has no name, can't have bookmarks
 	if filepath == "" then
 		return nil, nil
 	end
 
-	sync_lines_from_extmarks()
-
-	for i, bookmark in ipairs(bookmarks) do
+	for i, bookmark in ipairs(synced_bookmarks()) do
 		if bookmark.file == filepath and bookmark.line == line then
 			return bookmark, i
 		end
@@ -237,34 +188,23 @@ end
 
 --- Get bookmarks for a specific file, sorted by their current line.
 ---
---- `bookmarks_by_file` gives an O(k) membership lookup for the file, but its
---- *order* cannot be trusted: it is a binary insert keyed on line-at-insert-time
---- and is only rebuilt on load, while `sync_lines_from_extmarks` reassigns
---- `bookmark.line` in place as text is edited. The index holds references to the
---- same tables, so synced values show through — the ordering does not. Navigation
---- (`[h` / `]h`) scans for the first bookmark past the cursor and needs ascending
---- order, so sort after syncing.
----
---- Returns a fresh array of live bookmark references (not copies) — callers pass
---- them straight to hooks, which expect identity with the stored bookmark.
+--- Returns a fresh array of live bookmark references (not copies) — callers
+--- pass them straight to hooks, which expect identity with the stored bookmark.
 ---@param filepath string The normalized file path
 ---@return Bookmark[] bookmarks Array of bookmarks for the file, sorted by line
 function M.get_sorted_bookmarks_for_file(filepath)
-	ensure_loaded()
-
-	local file_bookmarks = bookmarks_by_file[filepath]
-	if not file_bookmarks or #file_bookmarks == 0 then
-		return {}
+	local file_bookmarks = {}
+	for _, bookmark in ipairs(synced_bookmarks()) do
+		if bookmark.file == filepath then
+			table.insert(file_bookmarks, bookmark)
+		end
 	end
 
-	sync_lines_from_extmarks()
-
-	local sorted = vim.list_slice(file_bookmarks, 1, #file_bookmarks)
-	table.sort(sorted, function(a, b)
+	table.sort(file_bookmarks, function(a, b)
 		return a.line < b.line
 	end)
 
-	return sorted
+	return file_bookmarks
 end
 
 --- Get all bookmarks as a deep copy.
@@ -274,9 +214,7 @@ end
 ---
 ---@return Bookmark[] bookmarks Array of all bookmarks
 function M.get_bookmarks()
-	ensure_loaded()
-	sync_lines_from_extmarks()
-	return vim.deepcopy(bookmarks)
+	return vim.deepcopy(synced_bookmarks())
 end
 
 --- Get bookmark locations as quickfix items.
@@ -291,64 +229,53 @@ function M.get_quickfix_items(opts)
 		append_annotations = true
 	end
 
-	local current_buffer = opts.current_buffer or false
-
-	-- Source from get_bookmarks() rather than reading `bookmarks` directly: it
-	-- syncs lines from extmarks first, so quickfix entries point at where a
-	-- bookmark is *now*, not where it was when it was created. The copy it
-	-- returns is also safe to sort without disturbing store order.
-	local active_bookmarks = M.get_bookmarks()
-
-	if current_buffer then
-		local current_file = utils.normalize_filepath(vim.api.nvim_buf_get_name(0))
+	local current_file = nil
+	if opts.current_buffer then
+		current_file = utils.normalize_filepath(vim.api.nvim_buf_get_name(0))
 		if current_file == "" then
 			return {}
 		end
-
-		local filtered = {}
-		for _, bookmark in ipairs(active_bookmarks) do
-			if bookmark.file == current_file then
-				table.insert(filtered, bookmark)
-			end
-		end
-		active_bookmarks = filtered
 	end
 
-	if #active_bookmarks == 0 then
-		return {}
-	end
-
-	table.sort(active_bookmarks, function(a, b)
-		if a.file == b.file then
-			return a.line < b.line
-		end
-		return a.file < b.file
-	end)
-
+	-- Build plain items straight off the live references — nothing here
+	-- mutates a bookmark, and the items themselves are what get sorted.
 	local items = {}
-	for _, bookmark in ipairs(active_bookmarks) do
-		local text = "Haunt bookmark"
-		if append_annotations and bookmark.note and bookmark.note ~= "" then
-			text = bookmark.note
-		end
+	for _, bookmark in ipairs(synced_bookmarks()) do
+		if not current_file or bookmark.file == current_file then
+			local text = "Haunt bookmark"
+			if append_annotations and bookmark.note and bookmark.note ~= "" then
+				text = bookmark.note
+			end
 
-		table.insert(items, {
-			filename = bookmark.file, -- absolute path works best for quickfix
-			lnum = bookmark.line,
-			col = 1,
-			text = text,
-		})
+			table.insert(items, {
+				filename = bookmark.file, -- absolute path works best for quickfix
+				lnum = bookmark.line,
+				col = 1,
+				text = text,
+			})
+		end
 	end
+
+	table.sort(items, function(a, b)
+		if a.filename == b.filename then
+			return a.lnum < b.lnum
+		end
+		return a.filename < b.filename
+	end)
 
 	return items
 end
 
---- Get raw reference to bookmarks array (for internal use only)
---- WARNING: Modifications to returned table affect internal state
+--- Get live references to all bookmarks (for internal use only).
+---
+--- This is the mutation channel: restoration and display toggles write extmark
+--- ids back onto the returned bookmarks, so they need identity with internal
+--- state — a copy would silently discard their writes.
+--- Lines are synced through the read funnel like every other accessor.
+--- WARNING: Modifications to the returned table affect internal state.
 ---@return Bookmark[] bookmarks Direct reference to bookmarks array
 function M.get_all_raw()
-	ensure_loaded()
-	return bookmarks
+	return synced_bookmarks()
 end
 
 --- Check if any bookmarks exist.
@@ -389,7 +316,6 @@ function M.load()
 	end
 
 	bookmarks = loaded_bookmarks
-	rebuild_file_index()
 	_loaded = true
 
 	local info = require("haunt.project").get_info()
@@ -411,7 +337,6 @@ end
 --- Used when changing data_dir to load from a new location.
 function M.reload()
 	bookmarks = {}
-	bookmarks_by_file = {}
 	_loaded = false
 	_loaded_project_id = nil
 	_loaded_project_root = nil
@@ -433,18 +358,20 @@ function M.save()
 	---@cast persistence -nil
 	---@cast hooks -nil
 
-	sync_lines_from_extmarks()
+	-- The funnel refreshes `.line` snapshots from extmarks; persistence then
+	-- serializes those snapshots. This is the only writer of snapshot state.
+	local synced = synced_bookmarks()
 
 	hooks.emit_pre_save({
-		bookmarks = bookmarks,
-		count = #bookmarks,
+		bookmarks = synced,
+		count = #synced,
 	})
 
-	local success = persistence.save_bookmarks(bookmarks, _loaded_storage_path, _loaded_project_root)
+	local success = persistence.save_bookmarks(synced, _loaded_storage_path, _loaded_project_root)
 
 	hooks.emit_post_save({
-		bookmarks = bookmarks,
-		count = #bookmarks,
+		bookmarks = synced,
+		count = #synced,
 		success = success,
 	})
 
@@ -479,7 +406,6 @@ end
 function M.add_bookmark(bookmark)
 	ensure_loaded()
 	table.insert(bookmarks, bookmark)
-	add_to_file_index(bookmark)
 end
 
 --- Remove a bookmark from the store
@@ -490,7 +416,6 @@ function M.remove_bookmark(bookmark)
 	for i, bm in ipairs(bookmarks) do
 		if bm.id == bookmark.id then
 			table.remove(bookmarks, i)
-			remove_from_file_index(bookmark)
 			return true
 		end
 	end
@@ -505,11 +430,7 @@ function M.remove_bookmark_at_index(index)
 	if index < 1 or index > #bookmarks then
 		return nil
 	end
-	local bookmark = table.remove(bookmarks, index)
-	if bookmark then
-		remove_from_file_index(bookmark)
-	end
-	return bookmark
+	return table.remove(bookmarks, index)
 end
 
 --- Clear all bookmarks for a specific file
@@ -532,9 +453,6 @@ function M.clear_file_bookmarks(filepath)
 		table.remove(bookmarks, indices_to_remove[i])
 	end
 
-	-- Clear from index
-	clear_file_from_index(filepath)
-
 	return removed
 end
 
@@ -544,7 +462,6 @@ function M.clear_all_bookmarks()
 	ensure_loaded()
 	local count = #bookmarks
 	bookmarks = {}
-	bookmarks_by_file = {}
 	return count
 end
 
@@ -554,7 +471,6 @@ end
 ---@private
 function M._reset_for_testing()
 	bookmarks = {}
-	bookmarks_by_file = {}
 	_loaded = true -- Prevent auto-loading from disk
 	_loaded_project_id = nil
 	_loaded_project_root = nil

--- a/tests/api_spec.lua
+++ b/tests/api_spec.lua
@@ -922,4 +922,71 @@ describe("haunt.api", function()
 			assert.are.equal("updated note", bookmarks[1].note)
 		end)
 	end)
+
+	-- Regression: issue #99. Same stale-line class as #92, but on the quickfix
+	-- path: get_quickfix_items read the module-level bookmarks table directly
+	-- instead of going through get_bookmarks(), so it never synced from
+	-- extmarks. :HauntQf jumped to the on-create line until something else
+	-- (opening :HauntList, or a save) happened to sync as a side effect.
+	describe("quickfix lines follow extmarks (issue #99)", function()
+		local bufnr, test_file
+
+		before_each(function()
+			bufnr, test_file = helpers.create_test_buffer({ "line 1", "line 2", "line 3", "line 4" })
+			vim.api.nvim_win_set_cursor(0, { 3, 0 })
+			api.annotate("on line 3")
+		end)
+
+		after_each(function()
+			helpers.cleanup_buffer(bufnr, test_file)
+		end)
+
+		it("reports the synced lnum after lines are inserted above", function()
+			local store = require("haunt.store")
+
+			-- Sanity check: quickfix points at the creation line
+			local before = store.get_quickfix_items()
+			assert.are.equal(1, #before)
+			assert.are.equal(3, before[1].lnum)
+
+			vim.api.nvim_buf_set_lines(bufnr, 0, 0, false, { "new top 1", "new top 2" })
+
+			local after = store.get_quickfix_items()
+			assert.are.equal(1, #after)
+			assert.are.equal(
+				5,
+				after[1].lnum,
+				"quickfix lnum should follow the extmark after 2 lines are inserted above (was "
+					.. tostring(after[1].lnum)
+					.. ")"
+			)
+		end)
+
+		it("does not require get_bookmarks to be called first", function()
+			-- The bug's tell: opening the picker repaired quickfix as a side
+			-- effect. Assert quickfix is correct on a cold read, with no
+			-- get_bookmarks() call in between.
+			local store = require("haunt.store")
+			vim.api.nvim_buf_set_lines(bufnr, 0, 0, false, { "new top 1", "new top 2" })
+
+			assert.are.equal(5, store.get_quickfix_items()[1].lnum)
+		end)
+
+		it("sorts by the synced line, not the stale one", function()
+			local store = require("haunt.store")
+
+			-- Second bookmark below the first, then push only the first one
+			-- down past it so stale ordering and synced ordering disagree.
+			vim.api.nvim_win_set_cursor(0, { 4, 0 })
+			api.annotate("on line 4")
+
+			vim.api.nvim_buf_set_lines(bufnr, 3, 3, false, { "pushed", "down" })
+
+			local items = store.get_quickfix_items()
+			assert.are.equal(2, #items)
+			assert.is_true(items[1].lnum < items[2].lnum, "items must be sorted by current line")
+			assert.are.equal(3, items[1].lnum)
+			assert.are.equal(6, items[2].lnum)
+		end)
+	end)
 end)

--- a/tests/commands_spec.lua
+++ b/tests/commands_spec.lua
@@ -219,6 +219,8 @@ describe("haunt user commands", function()
 	describe("HauntList", function()
 		local bufnr, test_file
 		local original_input
+		local original_ui_select
+		local ui_select_calls
 
 		before_each(function()
 			bufnr, test_file = helpers.create_test_buffer()
@@ -227,22 +229,36 @@ describe("haunt user commands", function()
 				return "Test"
 			end
 
+			-- No picker plugin is installed in the test env, so picker.show()
+			-- falls through to the vim.ui.select fallback. Neovim's default
+			-- implementation calls vim.fn.inputlist, which blocks on stdin and
+			-- hangs the headless run — stub it out and record the call instead.
+			ui_select_calls = {}
+			original_ui_select = vim.ui.select
+			vim.ui.select = function(items, opts, on_choice)
+				table.insert(ui_select_calls, { items = items, opts = opts, on_choice = on_choice })
+			end
+
 			vim.api.nvim_win_set_cursor(0, { 1, 0 })
 			vim.cmd("HauntAnnotate")
 		end)
 
 		after_each(function()
 			vim.fn.input = original_input
+			vim.ui.select = original_ui_select
 			helpers.cleanup_buffer(bufnr, test_file)
 		end)
 
 		it("calls picker.show without throwing", function()
-			-- HauntList requires Snacks.nvim which may not be installed in test env
-			-- We just verify the picker module can be required and show() can be called
 			local picker = require("haunt.picker")
 			local ok = pcall(picker.show)
-			-- Should not throw, even if Snacks is not available (it notifies instead)
 			assert.is_true(ok)
+		end)
+
+		it("HauntList reaches the picker", function()
+			vim.cmd("HauntList")
+
+			assert.are.equal(1, #ui_select_calls)
 		end)
 	end)
 

--- a/tests/navigation_spec.lua
+++ b/tests/navigation_spec.lua
@@ -247,4 +247,83 @@ describe("haunt.navigation", function()
 			assert.are.equal(1, pos3[1])
 		end)
 	end)
+
+	-- Regression: same stale-line family as #92/#99, on the navigation path.
+	-- get_sorted_bookmarks_for_file returned the file index without syncing
+	-- lines from extmarks, so `[h` / `]h` picked neighbours using the
+	-- on-create line instead of where the bookmark had moved to.
+	describe("navigation follows extmarks after edits", function()
+		local api
+
+		before_each(function()
+			local modules = helpers.setup_haunt()
+			api = modules.api
+			store = modules.store
+			navigation = modules.navigation
+
+			bufnr, test_file = helpers.create_test_buffer({
+				"line 1",
+				"line 2",
+				"line 3",
+				"line 4",
+				"line 5",
+				"line 6",
+			})
+
+			-- Bookmarks at lines 2 and 5, created through the real annotate
+			-- path so they carry tracking extmarks.
+			vim.api.nvim_win_set_cursor(0, { 2, 0 })
+			api.annotate("first")
+			vim.api.nvim_win_set_cursor(0, { 5, 0 })
+			api.annotate("second")
+		end)
+
+		it("jumps to the moved line, not the on-create line", function()
+			-- Push both bookmarks down by 3: extmarks now at lines 5 and 8.
+			vim.api.nvim_buf_set_lines(bufnr, 0, 0, false, { "new 1", "new 2", "new 3" })
+
+			vim.api.nvim_win_set_cursor(0, { 1, 0 })
+			navigation.next()
+
+			local pos = vim.api.nvim_win_get_cursor(0)
+			assert.are.equal(5, pos[1], "should jump to the first bookmark's current line, not its stale line 2")
+		end)
+
+		it("does not wrap early using stale lines", function()
+			vim.api.nvim_buf_set_lines(bufnr, 0, 0, false, { "new 1", "new 2", "new 3" })
+
+			-- Cursor sits between the two current positions (5 and 8). With
+			-- stale lines (2 and 5) nothing is past the cursor, so navigation
+			-- wrapped around to the first bookmark instead of advancing.
+			vim.api.nvim_win_set_cursor(0, { 6, 0 })
+			navigation.next()
+
+			local pos = vim.api.nvim_win_get_cursor(0)
+			assert.are.equal(8, pos[1], "should advance to the second bookmark rather than wrapping")
+		end)
+
+		it("prev uses moved lines too", function()
+			vim.api.nvim_buf_set_lines(bufnr, 0, 0, false, { "new 1", "new 2", "new 3" })
+
+			-- Cursor above both current positions (5 and 8), so prev must wrap
+			-- to the last bookmark. With stale lines (2 and 5) it instead found
+			-- a "previous" bookmark at line 2 and jumped backwards.
+			vim.api.nvim_win_set_cursor(0, { 4, 0 })
+			navigation.prev()
+
+			local pos = vim.api.nvim_win_get_cursor(0)
+			assert.are.equal(8, pos[1], "should wrap to the last bookmark's current line")
+		end)
+
+		it("returns bookmarks sorted by current line", function()
+			vim.api.nvim_buf_set_lines(bufnr, 0, 0, false, { "new 1", "new 2", "new 3" })
+
+			local filepath = require("haunt.utils").normalize_filepath(test_file)
+			local sorted = store.get_sorted_bookmarks_for_file(filepath)
+
+			assert.are.equal(2, #sorted)
+			assert.are.equal(5, sorted[1].line)
+			assert.are.equal(8, sorted[2].line)
+		end)
+	end)
 end)

--- a/tests/store_spec.lua
+++ b/tests/store_spec.lua
@@ -127,20 +127,16 @@ describe("haunt.store", function()
 			store.add_bookmark({ file = "/test.lua", line = 10, id = "target" })
 			store.add_bookmark({ file = "/test.lua", line = 20, id = "other" })
 
-			local bookmark, index = store.find_by_id("target")
+			local bookmark = store.find_by_id("target")
 
 			assert.is_not_nil(bookmark)
 			assert.are.equal("target", bookmark.id)
-			assert.are.equal(1, index)
 		end)
 
 		it("returns nil for non-existent ID", function()
 			store.add_bookmark({ file = "/test.lua", line = 10, id = "exists" })
 
-			local bookmark, index = store.find_by_id("nonexistent")
-
-			assert.is_nil(bookmark)
-			assert.is_nil(index)
+			assert.is_nil(store.find_by_id("nonexistent"))
 		end)
 	end)
 


### PR DESCRIPTION
## Checklist
- [x] Read `CONTRIBUTING.md`
- [x] Ran tests (`./scripts/test`) locally
- [x] Formatted with Stylua
- [x] Added tests if necessary
- [x] Updated documentation(inline to source code) if applicable
- [x] Updated `README.md` if applicable

## Summary
<!-- What does this PR change and/or fix? -->
Fix quick fix syncronization. also refactor to read from a safe place, too many of these bugs have happened, time to nail in the coffin