### PR TITLE
fix: refresh stale line numbers on focus

### DIFF
--- a/lua/haunt/api.lua
+++ b/lua/haunt/api.lua
@@ -793,6 +793,7 @@ function M.to_quickfix(opts)
 	vim.fn.setqflist({}, " ", {
 		title = title,
 		items = items,
+		context = { ["haunt.nvim"] = true },
 	})
 
 	utils.toggle_quickfix()

--- a/lua/haunt/api.lua
+++ b/lua/haunt/api.lua
@@ -774,6 +774,35 @@ function M.delete_by_id(bookmark_id)
 	return true
 end
 
+---@private
+local function attach_quickfix_refresh()
+	local qfbufnr = vim.fn.getqflist({ qfbufnr = 0 }).qfbufnr
+	if qfbufnr == 0 then
+		return
+	end
+
+	local augroup = vim.api.nvim_create_augroup("haunt_quickfix", { clear = true })
+	vim.api.nvim_create_autocmd("BufEnter", {
+		group = augroup,
+		buffer = qfbufnr,
+		callback = function()
+			local qf = vim.fn.getqflist({ all = 0 })
+			if type(qf.context) ~= "table" or qf.context["haunt.nvim"] ~= true then
+				return
+			end
+
+			-- Replacing the items refreshes stale quickfix text and integration caches.
+			local view = vim.fn.winsaveview()
+			vim.fn.setqflist({}, "u", {
+				id = qf.id,
+				items = qf.items,
+			})
+			vim.fn.winrestview(view)
+		end,
+		desc = "Refresh Haunt quickfix entries when focused",
+	})
+end
+
 --- Populate the quickfix list with haunt bookmarks.
 ---
 ---@param opts? QuickfixOpts Options for filtering and formatting
@@ -797,6 +826,7 @@ function M.to_quickfix(opts)
 	})
 
 	utils.toggle_quickfix()
+	attach_quickfix_refresh()
 
 	return true
 end

--- a/lua/haunt/init.lua
+++ b/lua/haunt/init.lua
@@ -291,6 +291,7 @@ end
 ---@private
 function M.setup_autocmds()
 	local augroup = vim.api.nvim_create_augroup("haunt_autosave", { clear = true })
+	local quickfix_augroup = vim.api.nvim_create_augroup("haunt_quickfix", { clear = true })
 
 	vim.api.nvim_create_autocmd("VimLeavePre", {
 		group = augroup,
@@ -316,6 +317,28 @@ function M.setup_autocmds()
 			end)
 		end,
 		desc = "Re-wrap above annotations to fit new window width",
+	})
+
+	vim.api.nvim_create_autocmd("WinEnter", {
+		group = quickfix_augroup,
+		callback = function()
+			local wininfo = vim.fn.getwininfo(vim.api.nvim_get_current_win())[1]
+			if not wininfo or wininfo.quickfix ~= 1 or wininfo.loclist == 1 then
+				return
+			end
+
+			local context = vim.fn.getqflist({ context = 0 }).context
+			if type(context) ~= "table" or context["haunt.nvim"] ~= true then
+				return
+			end
+
+			-- Neovim tracks quickfix item positions as the source buffer changes,
+			-- but an already-open quickfix buffer keeps its old rendered text.
+			local view = vim.fn.winsaveview()
+			vim.cmd("copen")
+			vim.fn.winrestview(view)
+		end,
+		desc = "Refresh Haunt quickfix entries when focused",
 	})
 end
 

--- a/lua/haunt/init.lua
+++ b/lua/haunt/init.lua
@@ -291,7 +291,6 @@ end
 ---@private
 function M.setup_autocmds()
 	local augroup = vim.api.nvim_create_augroup("haunt_autosave", { clear = true })
-	local quickfix_augroup = vim.api.nvim_create_augroup("haunt_quickfix", { clear = true })
 
 	vim.api.nvim_create_autocmd("VimLeavePre", {
 		group = augroup,
@@ -317,28 +316,6 @@ function M.setup_autocmds()
 			end)
 		end,
 		desc = "Re-wrap above annotations to fit new window width",
-	})
-
-	vim.api.nvim_create_autocmd("WinEnter", {
-		group = quickfix_augroup,
-		callback = function()
-			local wininfo = vim.fn.getwininfo(vim.api.nvim_get_current_win())[1]
-			if not wininfo or wininfo.quickfix ~= 1 or wininfo.loclist == 1 then
-				return
-			end
-
-			local context = vim.fn.getqflist({ context = 0 }).context
-			if type(context) ~= "table" or context["haunt.nvim"] ~= true then
-				return
-			end
-
-			-- Neovim tracks quickfix item positions as the source buffer changes,
-			-- but an already-open quickfix buffer keeps its old rendered text.
-			local view = vim.fn.winsaveview()
-			vim.cmd("copen")
-			vim.fn.winrestview(view)
-		end,
-		desc = "Refresh Haunt quickfix entries when focused",
 	})
 end
 


### PR DESCRIPTION
## Checklist
- [x] Read `CONTRIBUTING.md`
- [ ] Ran tests (`./scripts/test`) locally
- [x] Formatted with Stylua
- [x] Added tests if necessary
- [x] Updated documentation(inline to source code) if applicable
- [x] Updated `README.md` if applicable

## Summary
Fixes stale line numbers in an already-open quickfix window after source edits.
Haunt marks its quickfix list with context, then refreshes that list when the user focuses it again. The refresh preserves the quickfix window view.

I’m not fully sure this is the cleanest way to refresh an already-open quickfix window, so I’m happy to adjust it if you have a preferred approach!

---
## Testing
`./scripts/test` did not run successfully but reported 31 failures on the untouched `nightly` as well 😄 
